### PR TITLE
Add support to use an existing Redis client connection

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -28,12 +28,19 @@ var oneDay = 86400;
 var RedisStore = module.exports = function RedisStore(options) {
   options = options || {};
   Store.call(this, options);
-  this.client = new redis.createClient(options.port, options.host, options);
-  if (options.db) {
-    var self = this;
-    self.client.on('connect', function() {
-      self.client.select(options.db);
-    });
+  if (options.client) {
+    this.client = options.client;
+    if (options.db) {
+      this.client.select(options.db);
+    }
+  } else {
+    this.client = new redis.createClient(options.port, options.host, options);
+    if (options.db) {
+      var self = this;
+      self.client.on('connect', function() {
+        self.client.select(options.db);
+      });
+    }
   }
 };
 


### PR DESCRIPTION
I'm connecting to a remote Redis server on another machine (e.g. not using the default localhost IP/port) and using the connect-redis plugin as-is causes things to fail since it can't connect.  This change adds the ability to supply an existing client connection.
