### PR TITLE
Redis Authentication 

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,6 +16,7 @@ via npm:
   - `host` Redis server hostname
   - `port` Redis server portno
   - `db` Database index to use
+  - `pass` Password for Redis authentication
   - ...    Remaining options passed to the redis `createClient()` method.
 
 ## Example

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -29,10 +29,8 @@ var RedisStore = module.exports = function RedisStore(options) {
   options = options || {};
   Store.call(this, options);
   this.client = new redis.createClient(options.port, options.host, options);
-   if (options.pwd) {
-    client.auth(options.pwd, function () {
-      console.log('Redis authenticated');
-    });    
+  if (options.pass) {
+    client.auth(options.pwd, function () { });    
   }
 
   if (options.db) {


### PR DESCRIPTION
I want to use this on the Duostack hosting platform. http://docs.duostack.com/node/databases
We need to do authentication to the redis server, connect-redis doesn't support it. 

I propose we just check for the pwd on the options object and if its there do the authentication
