### PR TITLE
setting / getting values may not be happening in the selected db

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -37,9 +37,7 @@ var RedisStore = module.exports = function RedisStore(options) {
 
   if (options.db) {
     var self = this;
-    self.client.on('connect', function() {
-      self.client.select(options.db);
-    });
+    self.client.select(options.db);
   }
 };
 


### PR DESCRIPTION
according to node_redis doc, commands issued priore to 'ready' event is queued.  'select' command shouldn't be sent on 'connect event since RedisStore.set() may be invoked prior to 'select' which results in incorrect semantic (ie: setting a value in db 0 rather than the selected db)
