### PR TITLE
Allow passing socket option so that we can connect to a sockets as well

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -1,4 +1,3 @@
-
 /*!
  * Connect - Redis
  * Copyright(c) 2010 TJ Holowaychuk <tj@vision-media.ca>
@@ -43,7 +42,7 @@ module.exports = function(connect){
   function RedisStore(options) {
     options = options || {};
     Store.call(this, options);
-    this.client = new redis.createClient(options.port, options.host, options);
+    this.client = new redis.createClient(options.port || options.socket, options.host, options);
     if (options.pass) {
       this.client.auth(options.pass, function(err){
         if (err) throw err;


### PR DESCRIPTION
If you want to use a socket it has to be passed as the first argument to `redis.createServer`, and passing it as port is confusing and doesn't make much sense. Adding the ability to pass a `socket` option allows us to easily connect to sockets as well.
