### PR TITLE
DB is not reselected if the redis client disconnects temporarily

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -52,6 +52,11 @@ module.exports = function(connect){
     if (options.db) {
       var self = this;
       self.client.select(options.db);
+      self.client.on("connect", function() {
+        self.client.send_anyways = true;
+        self.client.select(options.db);
+        self.client.send_anyways = false;
+      });
     }
   };
 


### PR DESCRIPTION
I have been getting session objects in my db 0 after setting RedisStore with a different db. (and users losing session data that was in my session db).

This occurs if the client being used by RedisStore disconnects and then reconnects again. When its reconnected it doesn't reselect the proper db (by the nature of the node_redis client).

Related to node_redis [issue #86](https://github.com/mranney/node_redis/issues/86). 

I've added the work around noted in issue #86 node_redis.
