### PR TITLE
options.client + prefixed keys

### DIFF
--- a/examples/zstore.js
+++ b/examples/zstore.js
@@ -1,0 +1,78 @@
+/*
+ * Example showing the use of the event callbacks to maintain
+ * a list of all sessions.
+ */
+
+var assert     = require('assert')
+  , redis      = require('redis')
+  , connect    = require('connect')
+  , RedisStore = require('../')(connect);
+
+var ZStore = (function () {
+  function ZStore(client) {
+    RedisStore.call(this, client);
+
+    this.sessions = this.key('sessions');
+      
+    /* 
+     * [Explanation of set for keyspace.](redis.io/commands/keys)
+     * [Explanation of zset for keyspace with expiry.](http://groups.google.com/group/redis-db/browse_thread/thread/ad75cc08b364352b)
+     */
+
+    this.on('set', function(sid, ttl){
+      var self = this;
+      ttl = ttl * 1000;
+      self.client.zadd(self.sessions, new Date().getTime() + ttl, sid);
+      if (!self.timer) {
+        function timeout() {
+          var now = new Date().getTime();
+          self.client.zremrangebyscore(self.sessions, '-inf', now);
+          self.client.zrange(self.sessions, 0, 0, 'withscores', function (err, replies) {
+            if (replies.length != 0) {
+              self.timer = setTimeout(timeout, replies[1] - now);
+            } else {
+              self.timer = null;
+            }
+          });
+        }
+        self.timer = setTimeout(timeout, ttl);
+      }
+    });
+
+    this.on('destroy', function(sid){
+      this.client.zrem(this.sessions, sid);
+    });
+  };
+
+  ZStore.prototype.__proto__ = RedisStore.prototype;
+
+  ZStore.prototype.all = function(fn){
+    this.client.zrange(this.key('sessions'), 0, -1, fn);
+  };
+
+  return ZStore;
+})()
+
+var client  = redis.createClient()
+  , store   = new ZStore(client);
+
+store.set(connect.utils.uid(9), { cookie: { maxAge: 2000 }, k: 'v' });
+store.set(connect.utils.uid(9), { cookie: { maxAge: 2000 }, k: 'v' });
+store.set(connect.utils.uid(9), { cookie: { maxAge: 4000 }, k: 'v' });
+setTimeout(function(){
+  store.all(function(err, replies){
+    assert.ok(!err && replies.length == 3);
+  });
+}, 1000);
+setTimeout(function(){
+  store.all(function(err, replies){
+    assert.ok(!err && replies.length == 1); // prove zstore expires keys
+  });
+}, 3000);
+setTimeout(function(){
+  store.all(function(err, replies){
+    assert.ok(!err && replies.length == 0);
+    console.log('done');
+    client.quit();
+  });
+}, 5000);

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -5,12 +5,6 @@
  */
 
 /**
- * Module dependencies.
- */
-
-var redis = require('redis');
-
-/**
  * One day in seconds.
  */
 
@@ -39,25 +33,14 @@ module.exports = function(connect){
    * @api public
    */
 
-  function RedisStore(options) {
+  function RedisStore(client, options) {
+    if (!client) throw new Error('RedisStore() client required');
+    this.client = client;
+
     options = options || {};
     Store.call(this, options);
-    this.client = new redis.createClient(options.port || options.socket, options.host, options);
-    if (options.pass) {
-      this.client.auth(options.pass, function(err){
-        if (err) throw err;
-      });    
-    }
-
-    if (options.db) {
-      var self = this;
-      self.client.select(options.db);
-      self.client.on("connect", function() {
-        self.client.send_anyways = true;
-        self.client.select(options.db);
-        self.client.send_anyways = false;
-      });
-    }
+    options.prefix = options.prefix || 'session:';
+    this.key = function(key){ return options.prefix + key; };
   };
 
   /**
@@ -75,13 +58,17 @@ module.exports = function(connect){
    */
 
   RedisStore.prototype.get = function(sid, fn){
-    this.client.get(sid, function(err, data){
-      try {
-        if (!data) return fn();
-        fn(null, JSON.parse(data.toString()));
-      } catch (err) {
-        fn(err);
-      } 
+    this.client.get(this.key(sid), function(err, data){
+      if (err) {
+        fn.apply(this, arguments);
+      } else {
+        try {
+          data = JSON.parse(data.toString());
+        } catch (err) {
+          return fn(err);
+        }
+        fn(null, data);
+      }
     });
   };
 
@@ -95,18 +82,21 @@ module.exports = function(connect){
    */
 
   RedisStore.prototype.set = function(sid, sess, fn){
+    var maxAge = sess.cookie.maxAge
+      , ttl = 'number' == typeof maxAge
+        ? maxAge / 1000 | 0
+        : oneDay
+      , sess 
+      , self = this;
     try {
-      var maxAge = sess.cookie.maxAge
-        , ttl = 'number' == typeof maxAge
-          ? maxAge / 1000 | 0
-          : oneDay
-        , sess = JSON.stringify(sess);
-      this.client.setex(sid, ttl, sess, function(){
-        fn && fn.apply(this, arguments);
-      });
+      sess = JSON.stringify(sess);
     } catch (err) {
-      fn && fn(err);
-    } 
+      return fn && fn(err);
+    }
+    this.client.setex(this.key(sid), ttl, sess, function(err){
+      self.emit('set', sid, ttl);
+      fn && fn.apply(this, arguments);
+    });
   };
 
   /**
@@ -117,29 +107,11 @@ module.exports = function(connect){
    */
 
   RedisStore.prototype.destroy = function(sid, fn){
-    this.client.del(sid, fn);
-  };
-
-  /**
-   * Fetch number of sessions.
-   *
-   * @param {Function} fn
-   * @api public
-   */
-
-  RedisStore.prototype.length = function(fn){
-    this.client.dbsize(fn);
-  };
-
-  /**
-   * Clear all sessions.
-   *
-   * @param {Function} fn
-   * @api public
-   */
-
-  RedisStore.prototype.clear = function(fn){
-    this.client.flushdb(fn);
+    var self = this;
+    this.client.del(this.key(sid), function (err, reply) {
+      self.emit('destroy', sid);
+      fn && fn.apply(this, arguments);
+    });
   };
 
   return RedisStore;

--- a/test.js
+++ b/test.js
@@ -3,59 +3,53 @@
  * Module dependencies.
  */
 
-var assert = require('assert')
-  , connect = require('connect')
+var assert     = require('assert')
+  , redis      = require('redis')
+  , connect    = require('connect')
   , RedisStore = require('./')(connect);
 
-var store = new RedisStore;
-var store_alt = new RedisStore({ db: 15 });
+var client   = redis.createClient();
+var store    = new RedisStore(client);
+var storeAlt = new RedisStore(client, { prefix : 'alt:' }) 
+var sids     = [];
+
+store.on('set', function(sid, ttl){
+  sids.push(sid);
+})
+
+store.on('destroy', function(sid){
+  sids = sids.filter(function (x){ return x != sid; });
+})
 
 store.client.on('connect', function(){
   // #set()
   store.set('123', { cookie: { maxAge: 2000 }, name: 'tj' }, function(err, ok){
     assert.ok(!err, '#set() got an error');
     assert.ok(ok, '#set() is not ok');
+    assert.deepEqual(['123'], sids, '#set() did not emit event'); // assume expiry is not a factor 
     
     // #get()
     store.get('123', function(err, data){
       assert.ok(!err, '#get() got an error');
       assert.deepEqual({ cookie: { maxAge: 2000 }, name: 'tj' }, data);
   
-      // #length()
-      store.length(function(err, len){
-        assert.ok(!err, '#length() got an error');
-        assert.equal(1, len, '#length() with keys');
-
-        // #db option
-        store_alt.length(function (err, len) {
-          assert.ok(!err, '#alt db got an error');
-          assert.equal(0, len, '#alt db with keys'); 
-
-          // #clear()
-          store.clear(function(err, ok){
-            assert.ok(!err, '#clear()');
-            assert.ok(ok, '#clear()');
-
-            // #length()
-            store.length(function(err, len){
-              assert.ok(!err, '#length()');
-              assert.equal(0, len, '#length() without keys');
-
-              // #set null
-              store.set('123', { cookie: { maxAge: 2000 }, name: 'tj' }, function(){
-                store.destroy('123', function(){
-                  store.length(function(err, len){
-                   assert.equal(0, len, '#set() null');
-                   console.log('done');
-                   store.client.end(); 
-                   store_alt.client.end();
-                  });
-                });
-              });
+      // #destroy()
+      store.destroy('123', function(err){
+        assert.ok(!err, '#destroy() got an error');
+        assert.deepEqual([], sids, '#destroy() did not emit event');
+        store.get('123', function(err, data){
+          assert.ok(err, '#destroy() did not destroy the key');
+          
+          // options.prefix
+          storeAlt.set('123', { cookie: { maxAge: 2000 }, name: 'tj' }, function(err, ok){
+            client.get('alt:123', function(err, data){
+              assert.ok(!err, 'options.prefix is not prefixed to key');
+              console.log('done');
+              client.quit();
             });
           });
         });
       });
-    })
+    });
   });
 });


### PR DESCRIPTION
wrote my own patch as I needed pull #9, #14 solved. 

in particular, pull #14 doesn't properly implement RedisStore#length() or RedisStore#clear().

also, i took pull #9 to the logical extreme. options.client is required, as this defers the details of connection building to the user (no client.auth() in RedisStore!). 

this is similar to the approach on connect[master], where connect doesn't have to worry about building the server: connect.createServer() => http.createServer(connect()). :)
