### PR TITLE
DevDependencies of Connect version is set to 1.4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,6 @@
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "main": "./index.js",
   "dependencies": { "redis": ">= 0.0.1" },
-  "devDependencies": { "connect": "1.4.x" },
+  "devDependencies": { "connect": ">= 1.4.x" },
   "engines": { "node": ">= 0.1.98" }
 }


### PR DESCRIPTION
Pull this change for enable users to be able to install with the latest version of Connect.
