### PR TITLE
Added ttl option.

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -55,6 +55,8 @@ module.exports = function(connect){
       });    
     }
 
+    this.ttl =  options.ttl;
+
     if (options.db) {
       var self = this;
       self.client.select(options.db);
@@ -108,10 +110,11 @@ module.exports = function(connect){
     sid = this.prefix + sid;
     try {
       var maxAge = sess.cookie.maxAge
-        , ttl = 'number' == typeof maxAge
+        , ttl = this.ttl
+        , sess = JSON.stringify(sess);
+      if (ttl == null) ttl = 'number' == typeof maxAge
           ? maxAge / 1000 | 0
           : oneDay
-        , sess = JSON.stringify(sess);
 
       debug('SETEX "%s" ttl:%s %s', sid, sess);
       this.client.setex(sid, ttl, sess, function(err){


### PR DESCRIPTION
Added ttl option, which comes prior to cookie maxAge. Now session ttl is (options.ttl, cookie.maxAge, oneDay) whichever defined first.

If options.ttl is not defined, previous behaviour is preserved.
