### PR TITLE
Prevent node from crashing if there is a connection problem to Redis

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -42,6 +42,8 @@ module.exports = function(connect){
    */
 
   function RedisStore(options) {
+    var self = this;
+
     options = options || {};
     Store.call(this, options);
     this.prefix = null == options.prefix
@@ -49,6 +51,20 @@ module.exports = function(connect){
       : options.prefix;
 
     this.client = options.client || new redis.createClient(options.port || options.socket, options.host, options);
+
+    // If the safe mode is enabled, a conenction problem will not make node crash
+    // The connectionProblem flag will instead be set so that the problem can be gracefully handled by Connect's session middleware
+    // On reconnection, the connectionProblem flag gets unset and normal behaviour resumes
+    if (options.safeMode) {
+      this.client.on('error', function(err) {
+        self.connectionProblem = true;
+      });
+
+      this.client.on('connect', function() {
+        self.connectionProblem = false;
+      });
+    }
+
     if (options.pass) {
       this.client.auth(options.pass, function(err){
         if (err) throw err;


### PR DESCRIPTION
Hello,

I am using the session middleware for Connect with a Redis memory store managed by connect-redis. Currently, if it is not possible to connect to Redis (if it is down for example), node simply crashes. I find that having your whole server go down simply because your session store is not avaiable to be too much !

This PR enables me to use a "safe mode" that gracefully handles this situation by catching the error, preventing it from bubbling up and making node crash. In addition, a 'store.connectionProblem' flag is set up so that anyone using the Redis Store (in my case the session middleware) can also handle the error. The following PR on Connect shows how to handle this case  https://github.com/senchalabs/connect/pull/633

Cheers,
Louis
