### PR TITLE
Remove 5 minute reference

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -28,7 +28,6 @@ connect-redis is a Redis session store backed by [node_redis](http://github.com/
 
     connect.createServer(
       connect.cookieParser(),
-      // 5 minutes
       connect.session({ store: new RedisStore(options), secret: 'keyboard cat' })
     );
 


### PR DESCRIPTION
This comment appears to have been originally added in reference to a value that is no longer specified.

It's confusing, as it makes it look like some delay is occurring between the cookieParser and the session lines.
