### PR TITLE
RedisStore can have its users (e.g connect-session) handle connection to Redis problems

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -75,7 +75,6 @@ module.exports = function(connect){
 
   /**
    * Inherit from `Store`.
-   * Store is an EventEmitter so RedisStore is one too
    */
 
   RedisStore.prototype.__proto__ = Store.prototype;


### PR DESCRIPTION
Hello TJ,

As discussed [here](https://github.com/visionmedia/connect-redis/pull/50), I implemented a "safe mode" for the RedisStore. If enabled through the "safeMode" option, the 'error' event emitted by the redis driver is caught, preventing a node crash, and a 'connectionError' is emitted instead, which the user can use to know what state the RedisStore is in and act accordingly. In the case of Connect's session middleware, if the RedisStore is not ready, we simply pass the request to the next middleware, thus acting as if there was no session at all.

Related PR on connect : [PR #653](https://github.com/senchalabs/connect/pull/653)

Louis
