### PR TITLE
Use redis 0.8.x instead of 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.4.3",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "main": "./index.js",
-  "dependencies": { "redis": "0.8.0", "debug": "*" },
+  "dependencies": { "redis": "0.8.x", "debug": "*" },
   "devDependencies": { "connect": "*" },
   "engines": { "node": "*" }
 }


### PR DESCRIPTION
There is a bug in redis 0.8.0 that prevents connect-redis from working properly.

See here: https://github.com/mranney/node_redis/issues/267

I'm also suggesting we change this to 0.8.x as well
so we get other redis fixes as they become available
without having to update connect-redis itself.
