### PR TITLE
Update Redis Dependency to 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.4.5",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "main": "./index.js",
-  "dependencies": { "redis": "0.7.x", "debug": "*" },
+  "dependencies": { "redis": "0.8.x", "debug": "*" },
   "devDependencies": { "connect": "*" },
   "engines": { "node": "*" }
 }


### PR DESCRIPTION
Hi,

The revert to `node_redis` 0.7.x is no longer needed, [0.8.2 works fine](https://github.com/mranney/node_redis/blob/master/changelog.md).
