### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.4.5",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "main": "./index.js",
-  "dependencies": { "redis": "0.7.x", "debug": "*" },
+  "dependencies": { "redis": "0.8.x", "debug": "*" },
   "devDependencies": { "connect": "*" },
   "engines": { "node": "*" }
 }


### PR DESCRIPTION
Upgrade to [node_redis](https://github.com/mranney/node_redis) `0.8.x`, as `0.7.x` does not appear to be breaking.
