### PR TITLE
0.7.x of redis is too strict

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "connect-redis",
   "description": "Redis session store for Connect",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "main": "./index.js",
-  "dependencies": { "redis": "0.7.x", "debug": "*" },
+  "dependencies": { "redis": ">=0.7.x", "debug": "*" },
   "devDependencies": { "connect": "*" },
   "engines": { "node": "*" }
 }


### PR DESCRIPTION
my setups usually uses lalest redis (0.8.3 as of now). on each deploy, I need to remove 0.7.x (which gets installed with connect-redis) to use that latest version of redis.
