### PR TITLE
Add URL support for Redis connection

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -50,6 +50,26 @@ module.exports = function(connect){
       ? 'sess:'
       : options.prefix;
 
+    if (options.url) {
+        var url = require('url').parse(options.url);
+        if (url.protocol === 'redis:') {
+            if (url.user) {
+                var userparts = url.user.split(":");
+                options.user = userparts[0];
+                if (userparts.length === 2) {
+                    options.pass = urlparts[1];
+                }
+            }
+            options.host = url.hostname;
+            options.port = url.port;
+            if (url.pathname) {
+                options.db   = url.pathname.replace("/", "", 1);
+            }
+        }
+    }
+    
+    console.log(options);
+
     this.client = options.client || new redis.createClient(options.port || options.socket, options.host, options);
     if (options.pass) {
       this.client.auth(options.pass, function(err){

--- a/test.js
+++ b/test.js
@@ -9,6 +9,7 @@ var assert = require('assert')
 
 var store = new RedisStore;
 var store_alt = new RedisStore({ db: 15 });
+var store_url = new RedisStore({ url: "redis://localhost:6379/db2" });
 
 store.client.on('connect', function(){
   // #set()
@@ -27,6 +28,7 @@ store.client.on('connect', function(){
          console.log('done');
          store.client.end(); 
          store_alt.client.end();
+         store_url.client.end();
         });
       });
       throw new Error('Error in fn');


### PR DESCRIPTION
This allows go give an url of the type:
redis://user:password@server:port/dbname to configure the connection.
