### PR TITLE
Unref redis client

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -50,6 +50,7 @@ module.exports = function(connect){
       : options.prefix;
 
     this.client = options.client || new redis.createClient(options.port || options.socket, options.host, options);
+    this.client.unref();
     if (options.pass) {
       this.client.auth(options.pass, function(err){
         if (err) throw err;


### PR DESCRIPTION
This middleware prevents processes from terminating because of its Redis client (annoying when you are testing). I don't see any reason (is there?) why it should so I added an unref() call to the redis client.
