### PR TITLE
Add optional merging of the session data on set(). 

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -145,7 +145,7 @@ module.exports = function(connect){
             debug(oSess);
             sess = JSON.stringify(self.merge(result, oSess));
           }
-          console.log('SETEX "%s" ttl:%s %s', sid, ttl, sess);
+          debug('SETEX "%s" ttl:%s %s', sid, ttl, sess);
           self.client.setex(sid, ttl, sess, function(err){
             err || debug('SETEX complete');
             fn && fn.apply(this, arguments);


### PR DESCRIPTION
This prevents data getting lost when multiple asynchronous ajax requests are fired at the server. Each ajax call will do a set() when it's done, but that will overwrite request data that has just been set during the ajax call by another one.

Enable by setting `merge: true` in the options.

This solves problems like this one:
http://stackoverflow.com/questions/5883821/node-js-express-session-problem

Probably needs some tests to be sure it always works as you wish, this pull request is to ask you guys for comments on this approach.
