### PR TITLE
added repository field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.4.5",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "main": "./index.js",
+  "repository": { "type": "git", "url": "https://github.com/visionmedia/connect-redis.git" },
   "dependencies": { "redis": "0.7.x", "debug": "*" },
   "devDependencies": { "connect": "*" },
   "engines": { "node": "*" }


### PR DESCRIPTION
newer versions of `npm` gives a warning if this field isn't present on `npm install`. Solves #84
