### PR TITLE
store: fix silently swallowing redis errors

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -52,7 +52,7 @@ module.exports = function(connect){
     if (options.pass) {
       this.client.auth(options.pass, function(err){
         if (err) throw err;
-      });    
+      });
     }
 
     this.ttl =  options.ttl;
@@ -66,7 +66,11 @@ module.exports = function(connect){
       });
     }
 
-    self.client.on('error', function () { self.emit('disconnect'); });
+    self.client.on('error', function (error) {
+      self.emit('error', error);
+
+      self.emit('disconnect');
+    });
     self.client.on('connect', function () { self.emit('connect'); });
   };
 
@@ -94,7 +98,7 @@ module.exports = function(connect){
       data = data.toString();
       debug('GOT %s', data);
       try {
-        result = JSON.parse(data); 
+        result = JSON.parse(data);
       } catch (err) {
         return fn(err);
       }
@@ -129,7 +133,7 @@ module.exports = function(connect){
       });
     } catch (err) {
       fn && fn(err);
-    } 
+    }
   };
 
   /**


### PR DESCRIPTION
This allows errors to propagate properly.

Having connect-redis listen to this prevents the exception from being thrown. However, since we might still want to pass the error down the stack, log what the error was anyways, just in case.


@visionmedia I'm guessing it would be better to throw an actual exception, but I'm not sure how to do that with a pre-existing Error object and listeners.