### PR TITLE
Parse url database # into Number

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -65,7 +65,7 @@ module.exports = function(session){
         options.host = url.hostname;
         options.port = url.port;
         if (url.pathname) {
-          options.db   = url.pathname.replace("/", "", 1);
+          options.db   = parseInt(url.pathname.replace("/", "", 1), 10);
         }
       }
     }
@@ -138,7 +138,7 @@ module.exports = function(session){
       data = data.toString();
       debug('GOT %s', data);
       try {
-        result = JSON.parse(data); 
+        result = JSON.parse(data);
       } catch (err) {
         return fn(err);
       }
@@ -173,7 +173,7 @@ module.exports = function(session){
       });
     } catch (err) {
       fn && fn(err);
-    } 
+    }
   };
 
   /**


### PR DESCRIPTION
Currently logs a warning:

```
Warning: connect-redis expects a number for the "db" option
```

This correctly parses the 'db' param into a number.
