### PR TITLE
adding debug statement for redis client errors

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -120,6 +120,7 @@ module.exports = function (session) {
     }
 
     self.client.on('error', function (er) {
+      debug('Redis returned err', er);
       self.emit('disconnect', er);
     });
 


### PR DESCRIPTION
Getting a ton of `Fri, 15 May 2015 15:01:16 GMT express-session store is disconnected` from using debug with [express/session](express/session).

However, even when we add `connect:redis` to the `DEBUG` line we don't see what the error is with redis that is causing this to print.  We do know our redis instance is up (we're using it for other things), so we need to see what the error is. (express-session does not print out the error when the client disconnects.)

I've made a different version and published it as a scoped NPM module so we can do our debugging, but it would be cool to be able to see the error in the debug logs.