### PR TITLE
Add support to override serializer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,6 +30,7 @@ The following additional params may be included:
   - `pass` Password for Redis authentication
   - `prefix` Key prefix defaulting to "sess:"
   - `unref` Set `true` to unref the Redis client. **Warning**: this is [an experimental feature](https://github.com/mranney/node_redis#clientunref).
+  - `serializer` An object containing `stringify` and `parse` methods compatible with Javascript's `JSON` to override the serializer used
 
 Any options not included in this list will be passed to the redis `createClient()` method directly.
 

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -55,6 +55,8 @@ module.exports = function (session) {
       ? 'sess:'
       : options.prefix;
 
+    this.serializer = options.serializer || JSON;
+
     /* istanbul ignore next */
     if (options.url) {
       console.error('Warning: "url" param is deprecated and will be removed in a later release: use redis-url module instead');
@@ -156,7 +158,7 @@ module.exports = function (session) {
       debug('GOT %s', data);
 
       try {
-        result = JSON.parse(data);
+        result = store.serializer.parse(data);
       }
       catch (er) {
         return fn(er);
@@ -180,7 +182,7 @@ module.exports = function (session) {
     if (!fn) fn = noop;
 
     try {
-      var jsess = JSON.stringify(sess);
+      var jsess = store.serializer.stringify(sess);
     }
     catch (er) {
       return fn(er);

--- a/test/connect-redis-test.js
+++ b/test/connect-redis-test.js
@@ -101,3 +101,18 @@ test('interups', function (t) {
       store.client.end();
     });
 });
+
+test('serializer', function (t) {
+  var serializer = {
+    stringify: function() { return 'XXX'+JSON.stringify.apply(JSON, arguments); },
+    parse: function(x) {
+      t.ok(x.match(/^XXX/));
+      return JSON.parse(x.substring(3));
+    }
+  };
+  t.equal(serializer.stringify('UnitTest'), 'XXX"UnitTest"');
+  t.equal(serializer.parse(serializer.stringify("UnitTest")), 'UnitTest');
+
+  var store = new RedisStore({ port: 8543, serializer: serializer });
+  return lifecycleTest(store, t); 
+});


### PR DESCRIPTION
This PR adds a new config option to specify an alternate serializer for the payloads going into Redis.  The default is to use JSON for full backwards compatibility.

This would allow those who need more advanced serialization or have other transport needs (like payload encryption) to inject these by using alternate parse and stringify methods.