### PR TITLE
Update node redis to 2.0

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,6 +21,7 @@ Then follow the usage instructions below.
   - `host` Redis server hostname
   - `port` Redis server portno
   - `socket` Redis server unix_socket
+  - `url` Redis server url
 
 The following additional params may be included:
 
@@ -53,10 +54,6 @@ Clients other than `node_redis` will work if they support the same interface.  J
   * [ioredis](https://github.com/luin/ioredis) - adds support for Redis Sentinel and Cluster
 
 ## FAQ
-
-#### Can I use a URL scheme to make a connection?
-
-Since `node_redis` which this library wraps does not include the ability to create a client from a URL.  Neither does this library.  However, there's a [separate module](https://github.com/ddollar/redis-url) that can be used in conjunction to get this behavior.
 
 #### How do I handle lost connections to Redis?
 

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -54,6 +54,7 @@ module.exports = function (session) {
     var self = this;
 
     options = options || {};
+    options.max_attempts = 2;
     Store.call(this, options);
     this.prefix = options.prefix == null
       ? 'sess:'
@@ -63,22 +64,8 @@ module.exports = function (session) {
 
     /* istanbul ignore next */
     if (options.url) {
-      console.error('Warning: "url" param is deprecated and will be removed in a later release: use redis-url module instead');
-      var url = require('url').parse(options.url);
-      if (url.protocol === 'redis:') {
-        if (url.auth) {
-          var userparts = url.auth.split(':');
-          options.user = userparts[0];
-          if (userparts.length === 2) {
-            options.pass = userparts[1];
-          }
-        }
-        options.host = url.hostname;
-        options.port = url.port;
-        if (url.pathname) {
-          options.db = url.pathname.replace('/', '', 1);
-        }
-      }
+      options.port = options.url;
+      options.host = options;
     }
 
     // convert to redis connect params

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "debug": "^1.0.4",
-    "redis": "^0.12.1"
+    "redis": "^2.0.1"
   },
   "devDependencies": {
     "blue-tape": "^0.1.8",

--- a/test/connect-redis-test.js
+++ b/test/connect-redis-test.js
@@ -31,7 +31,7 @@ function lifecycleTest (store, t) {
     .then(function (ok) {
       t.equal(ok, 1, '#destroy() ok');
       store.client.end();
-      return redisSrv.disconnect()
+      return redisSrv.disconnect();
     });
 }
 
@@ -54,13 +54,13 @@ test('basic', function (t) {
 
 test('existing client', function (t) {
   var client = redis.createClient(8543, 'localhost');
-  var store = new RedisStore({ client: client })
+  var store = new RedisStore({ client: client });
   return lifecycleTest(store, t);
 });
 
 test('io redis client', function (t) {
   var client = ioRedis.createClient(8543, 'localhost');
-  var store = new RedisStore({ client: client })
+  var store = new RedisStore({ client: client });
   return lifecycleTest(store, t);
 });
 
@@ -84,21 +84,20 @@ test('options', function (t) {
 
   var socketStore = new RedisStore({ socket: 'word' });
   t.equal(socketStore.client.address, 'word', 'sets socket address');
-  socketStore.client.end()
+  socketStore.client.end();
 
   var hostNoPort = new RedisStore({ host: 'host' });
   t.equal(hostNoPort.client.address, 'host:6379', 'sets default port');
-  hostNoPort.client.end()
+  hostNoPort.client.end();
 
   return lifecycleTest(store, t);
 });
 
 test('interups', function (t) {
   var store = P.promisifyAll(new RedisStore({ port: 8543 }));
-
   return store.setAsync('123', { cookie: { maxAge: 2000 }, name: 'tj' })
     .catch(function (er) {
-      t.ok(/failed/.test(er.message), 'failed connection');
+      t.ok(/broken/.test(er.message), 'failed connection');
       store.client.end();
     });
 });
@@ -115,5 +114,5 @@ test('serializer', function (t) {
   t.equal(serializer.parse(serializer.stringify("UnitTest")), 'UnitTest');
 
   var store = new RedisStore({ port: 8543, serializer: serializer });
-  return lifecycleTest(store, t); 
+  return lifecycleTest(store, t);
 });


### PR DESCRIPTION
node redis had a major overhaul and I highly recommend updating. 2.0 has some breaking changes tough and does not behave the same as before all the same.

From version 1.0 on node_redis supports the redis url schema and from version 2.0 on the connection behavior changed. The change to max_attempts is likely not what you want but the promise would otherwise never end right now, as there won't be any error thrown while trying to reconnect. Only if node_redis gave up reconnecting, it'll throw an error from v2 on. 

With v.2 you can also likely fix #159, since from now on it would be possible to try reconnecting until a certain amount of retries.