### PR TITLE
Remove attempts option and some minor refactoring

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,9 @@
 
+3.0.1 / 2015-xx-xx
+==================
+
+  * Remove attempts option added in 3.0 to enable reconnect again [fintura]
+
 3.0.0 / 2015-10-03
 ==================
 

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -6,8 +6,6 @@
 
 var debug = require('debug')('connect:redis');
 var redis = require('redis');
-var default_port = 6379;
-var default_host = '127.0.0.1';
 var util = require("util");
 var noop = function(){};
 
@@ -55,7 +53,6 @@ module.exports = function (session) {
     var self = this;
 
     options = options || {};
-    options.max_attempts = 2;
     Store.call(this, options);
     this.prefix = options.prefix == null
       ? 'sess:'
@@ -63,10 +60,8 @@ module.exports = function (session) {
 
     this.serializer = options.serializer || JSON;
 
-    /* istanbul ignore next */
     if (options.url) {
-      options.port = options.url;
-      options.host = options;
+      options.socket = options.url;
     }
 
     // convert to redis connect params
@@ -75,13 +70,6 @@ module.exports = function (session) {
     }
     else if (options.socket) {
       this.client = redis.createClient(options.socket, options);
-    }
-    else if (options.port || options.host) {
-      this.client = redis.createClient(
-        options.port || default_port,
-        options.host || default_host,
-        options
-      );
     }
     else {
       this.client = redis.createClient(options);
@@ -170,7 +158,7 @@ module.exports = function (session) {
 
   RedisStore.prototype.set = function (sid, sess, fn) {
     var store = this;
-    var psid = store.prefix + sid;
+    var args = [store.prefix + sid];
     if (!fn) fn = noop;
 
     try {
@@ -180,23 +168,20 @@ module.exports = function (session) {
       return fn(er);
     }
 
-    if (store.disableTTL) {
+    args.push(jsess);
+
+    if (!store.disableTTL) {
+      var ttl = getTTL(store, sess);
+      args.push('EX', ttl);
+      debug('SET "%s" %s ttl:%s', sid, jsess, ttl);
+    } else {
       debug('SET "%s" %s', sid, jsess);
-      store.client.set(psid, jsess, function (er) {
-        if (er) return fn(er);
-        debug('SET complete');
-        fn.apply(null, arguments);
-      });
-      return;
     }
 
-    var ttl = getTTL(store, sess);
-
-    debug('SETEX "%s" ttl:%s %s', sid, ttl, jsess);
-    store.client.setex(psid, ttl, jsess, function (er) {
+    store.client.set(args, function (er) {
       if (er) return fn(er);
-      debug('SETEX complete');
-      fn.apply(this, arguments);
+      debug('SET complete');
+      fn.apply(null, arguments);
     });
   };
 

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -8,6 +8,7 @@ var debug = require('debug')('connect:redis');
 var redis = require('redis');
 var default_port = 6379;
 var default_host = '127.0.0.1';
+var util = require("util");
 var noop = function(){};
 
 /**
@@ -124,7 +125,7 @@ module.exports = function (session) {
    * Inherit from `Store`.
    */
 
-  RedisStore.prototype.__proto__ = Store.prototype;
+  util.inherits(RedisStore, Store);
 
   /**
    * Attempt to fetch session by the given `sid`.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
-    "redis": "^2.0.1"
+    "redis": "^2.1.0"
   },
   "devDependencies": {
     "blue-tape": "^0.1.8",

--- a/test/connect-redis-test.js
+++ b/test/connect-redis-test.js
@@ -86,6 +86,10 @@ test('options', function (t) {
   t.equal(socketStore.client.address, 'word', 'sets socket address');
   socketStore.client.end();
 
+  var urlStore = new RedisStore({ url: 'redis://127.0.0.1:8888' });
+  t.equal(urlStore.client.address, '127.0.0.1:8888', 'sets url address');
+  urlStore.client.end();
+
   var hostNoPort = new RedisStore({ host: 'host' });
   t.equal(hostNoPort.client.address, 'host:6379', 'sets default port');
   hostNoPort.client.end();
@@ -94,7 +98,7 @@ test('options', function (t) {
 });
 
 test('interups', function (t) {
-  var store = P.promisifyAll(new RedisStore({ port: 8543 }));
+  var store = P.promisifyAll(new RedisStore({ port: 8543, connect_timeout: 500 }));
   return store.setAsync('123', { cookie: { maxAge: 2000 }, name: 'tj' })
     .catch(function (er) {
       t.ok(/broken/.test(er.message), 'failed connection');


### PR DESCRIPTION
This removes the attempts option as a default again. It is only needed for the test, since otherwise the test would have waited forever to resolve. I added a timeout to the test itself instead.

Reconnecting will not work properly until this is merged.

I also refactored some parts that were obsolete, since they are handled by node_redis (and ioredis) already.

SETEX might get deprecated at some point as stated in the redis docs, so I refactored that too.