### PR TITLE
Remove prefix option passed to node_redis

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -58,6 +58,8 @@ module.exports = function (session) {
       ? 'sess:'
       : options.prefix;
 
+    delete options.prefix;
+
     this.serializer = options.serializer || JSON;
 
     if (options.url) {


### PR DESCRIPTION
A few days ago node-redis added a "prefix" option of it's own: https://github.com/NodeRedis/node_redis/releases/tag/v.2.4.0

This has resulted in a double-prefixing effect where if I specify `{ ... prefix: 'aaa:' }` in the options, the  key that is set in redis is `aaa:aaa:{randomId}` rather than simply `aaa:{randomId}`.

The proposed fix here is very basic in nature, but it does resolve the issue. A better solution would be to adopt the prefix option used by node-redis and just delete all of the prefixing logic here.

