### PR TITLE
Remove node_redis as a hard dependency

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -65,10 +65,10 @@ module.exports = function (session, redis) {
     delete options.prefix;
 
     this.serializer = options.serializer || JSON;
-	
-	//assign the redis client
-	this.client = Redis;
-	
+
+    //assign the redis client
+    this.client = Redis;
+
     if (options.pass) {
       this.client.auth(options.pass, function (err) {
         if (err) {

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -30,13 +30,18 @@ function getTTL(store, sess) {
  * @api public
  */
 
-module.exports = function (session) {
+module.exports = function (session, redis) {
 
   /**
    * Express's session Store.
    */
 
   var Store = session.Store;
+  
+  /**
+  * Redis client
+  */ 
+  var Redis = redis;
 
   /**
    * Initialize RedisStore with the given `options`.
@@ -61,22 +66,10 @@ module.exports = function (session) {
     delete options.prefix;
 
     this.serializer = options.serializer || JSON;
-
-    if (options.url) {
-      options.socket = options.url;
-    }
-
-    // convert to redis connect params
-    if (options.client) {
-      this.client = options.client;
-    }
-    else if (options.socket) {
-      this.client = redis.createClient(options.socket, options);
-    }
-    else {
-      this.client = redis.createClient(options);
-    }
-
+	
+	//assign the redis client
+	this.client = Redis;
+	
     if (options.pass) {
       this.client.auth(options.pass, function (err) {
         if (err) {

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -5,7 +5,6 @@
  */
 
 var debug = require('debug')('connect:redis');
-var redis = require('redis');
 var util = require('util');
 var noop = function(){};
 

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "url": "git@github.com:visionmedia/connect-redis.git"
   },
   "dependencies": {
-    "debug": "^2.2.0",
-    "redis": "^2.1.0"
+    "debug": "^2.2.0"
   },
   "devDependencies": {
     "blue-tape": "^0.1.8",


### PR DESCRIPTION
Is there a reason this is a hard dependency? I don't see why `node_redis` needs to be installed as well if using another redis client (ie ioredis)


Setup then becomes

```sh
npm install redis connect-redis express-session 
```

```js
var redis = require('redis');
var session = require('express-session');
var RedisStore = require('connect-redis')(session, redis.createClient());

app.use(session({
    store: new RedisStore(options),
    secret: 'keyboard cat'
}));
```