### PR TITLE
Add option logErrors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,6 +39,7 @@ The following additional params may be included:
   - `prefix` Key prefix defaulting to "sess:"
   - `unref` Set `true` to unref the Redis client. **Warning**: this is [an experimental feature](https://github.com/mranney/node_redis#clientunref).
   - `serializer` An object containing `stringify` and `parse` methods compatible with Javascript's `JSON` to override the serializer used
+  - `logErrors` Whether or not to log client errors. if true, a default logging function is provided. if a function is passed, this function will be executed anytime an error occurs, which would be useful for those implementing custom loggers in their deployment. if false, nothing is logged.
 
 Any options not included in this list will be passed to the redis `createClient()` method directly.
 

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -76,6 +76,18 @@ module.exports = function (session) {
     else {
       this.client = redis.createClient(options);
     }
+    
+    // logErrors
+    if(options.logErrors){
+      // if options.logErrors is function, allow it to override. else provide default logger. useful for large scale deployment
+      // which may need to write to a distributed log
+      if(typeof options.logErrors != 'function'){
+        options.logErrors = function (err) {
+  			  console.log('Warning connect-redis reported a client error: ' + err);
+  		  };
+      }
+  		this.client.on('error', options.logErrors);	
+  	}
 
     if (options.pass) {
       this.client.auth(options.pass, function (err) {

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -83,7 +83,7 @@ module.exports = function (session) {
       // which may need to write to a distributed log
       if(typeof options.logErrors != 'function'){
         options.logErrors = function (err) {
-  			  console.log('Warning connect-redis reported a client error: ' + err);
+  			  console.error('Warning: connect-redis reported a client error: ' + err);
   		  };
       }
   		this.client.on('error', options.logErrors);	


### PR DESCRIPTION
This adds an option to log client errors. 

highlights:

if `false` - does nothing
if `true` - logs all client errors with console.log
if `function` - provides function as callback to 'error' event.