### PR TITLE
Implemented setClient()

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -53,6 +53,8 @@ module.exports = function (session) {
     var self = this;
 
     options = options || {};
+    this.options = options;
+    
     Store.call(this, options);
     this.prefix = options.prefix == null
       ? 'sess:'
@@ -66,16 +68,33 @@ module.exports = function (session) {
       options.socket = options.url;
     }
 
+    var client;
+
     // convert to redis connect params
     if (options.client) {
-      this.client = options.client;
+      client = options.client;
     }
     else if (options.socket) {
-      this.client = redis.createClient(options.socket, options);
+      client = redis.createClient(options.socket, options);
     }
     else {
-      this.client = redis.createClient(options);
+      client = redis.createClient(options);
     }
+
+    self._clientConnectHandler = function(){
+      if ('db' in self.options) {
+        self.client.select(self.options.db);
+      }
+
+      self.emit('connect');
+    };
+
+    self._clientErrorHandler = function(er){
+      debug('Redis returned err', er);
+      self.emit('disconnect', er);
+    };
+
+    self.setClient( client );
     
     // logErrors
     if(options.logErrors){
@@ -86,42 +105,58 @@ module.exports = function (session) {
   			  console.error('Warning: connect-redis reported a client error: ' + err);
   		  };
       }
-  		this.client.on('error', options.logErrors);	
   	}
 
-    if (options.pass) {
-      this.client.auth(options.pass, function (err) {
+    this.ttl = options.ttl;
+    this.disableTTL = options.disableTTL;
+  }
+
+  /**
+   * Sets new redis client
+   * @param client
+   */
+
+  RedisStore.prototype.setClient = function( client ) {
+    var self = this;
+
+    if( self.client ){
+      self.client.removeListener( 'connect', self._clientConnectHandler );
+
+      if(self.options.logErrors){
+        self.client.removeListener( 'error', self.options.logErrors );
+      }
+
+      self.client.removeListener( 'error', this._clientErrorHandler );
+    }
+
+    self.client = client;
+
+    if(self.options.logErrors){
+      self.client.on('error', self.options.logErrors);
+    }
+
+    if (self.options.pass) {
+      self.client.auth(self.options.pass, function (err) {
         if (err) {
           throw err;
         }
       });
     }
 
-    this.ttl = options.ttl;
-    this.disableTTL = options.disableTTL;
+    if (self.options.unref) this.client.unref();
 
-    if (options.unref) this.client.unref();
-
-    if ('db' in options) {
-      if (typeof options.db !== 'number') {
+    if ('db' in self.options) {
+      if (typeof self.options.db !== 'number') {
         console.error('Warning: connect-redis expects a number for the "db" option');
       }
 
-      self.client.select(options.db);
-      self.client.on('connect', function () {
-        self.client.select(options.db);
-      });
+      self.client.select(self.options.db);
     }
 
-    self.client.on('error', function (er) {
-      debug('Redis returned err', er);
-      self.emit('disconnect', er);
-    });
+    self.client.on('error', self._clientErrorHandler );
 
-    self.client.on('connect', function () {
-      self.emit('connect');
-    });
-  }
+    self.client.on('connect', self._clientConnectHandler );
+  };
 
   /**
    * Inherit from `Store`.


### PR DESCRIPTION
Most recent versions of https://github.com/NodeRedis/node_redis do give up on reconnection after certain criteria are met (e.g. retry timeout exceeded, etc.) Unfortunately, that means, that result of `redis.createClient()` becomes junk, and new connection should be created.

In this PR I've implemented setClient() to allow app to replace client on RedisStore, e.g. in cases like this.