### PR TITLE
allow .destroy to be called without a callback

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -203,10 +203,12 @@ module.exports = function (session) {
    * Destroy the session associated with the given `sid`.
    *
    * @param {String} sid
+   * @param {Function} fn
    * @api public
    */
 
   RedisStore.prototype.destroy = function (sid, fn) {
+    if (!fn) fn = noop;
     debug('DEL "%s"', sid);
     if (Array.isArray(sid)) {
       var multi = this.client.multi();


### PR DESCRIPTION
When `req.session.destroy` is called without a callback function, the `fn` parameter is passed to the Redis instance as `undefined`. I did not check how `node_redis` works with this, but `ioredis` interprets the `undefined` parameter as second value to be deleted from the database:

this works, "myPrefix<sessionId>" is deleted:

``` 
(req, res, next) => {
    req.session.destroy(next);
}
```

this tries to delete "myPrefix", which not only generates an additional network roundtrip, but may also lead to CROSSSLOT problems:

``` 
(req, res, next) => {
    req.session.destroy(); // we don't care about the result
    next();
}
```

The other function check if there is a `fn` parameter and fill in an empty function if not.