### PR TITLE
listen on end event

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -117,6 +117,10 @@ module.exports = function (session) {
       debug('Redis returned err', er);
       self.emit('disconnect', er);
     });
+    
+    self.client.on('end', function () {
+      self.emit('disconnect', new Error('redis server disconnect'));
+    });    
 
     self.client.on('connect', function () {
       self.emit('connect');


### PR DESCRIPTION
var Redis = require('redis');
var redisCli = Redis.createClient({
     retry_strategy : function(options){
            return 500;
    }
}) 

var redis_store = new RedisStore({client : client});
 
redis_store.once('disconnect', function(){
       //TODO
})
[https://github.com/NodeRedis/node_redis](url)
redisCli will emit end when an established Redis server connection has closed.
