### PR TITLE
Add support for store.ttl fn.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,6 +35,7 @@ A Redis client is required. An existing client can be passed directly using the 
 The following additional params may be included:
 
 -	`ttl` Redis session TTL (expiration) in seconds. Defaults to session.maxAge (if set), or one day.
+	-	This may also be set to a function of the form `(store, sess, sessionID) => number`.
 -	`disableTTL` Disables setting TTL, keys will stay in redis until evicted by other means (overides `ttl`\)
 -	`db` Database index to use. Defaults to Redis's default (0).
 -	`pass` Password for Redis authentication

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -15,9 +15,13 @@ var noop = function(){};
 
 var oneDay = 86400;
 
-function getTTL(store, sess) {
+function getTTL(store, sess, sid) {
+  if (typeof store.ttl === 'number') return store.ttl;
+  if (typeof store.ttl === 'function') return store.ttl(store, sess, sid);
+  if (store.ttl) throw new TypeError('`store.ttl` must be a number or function.');
+
   var maxAge = sess.cookie.maxAge;
-  return store.ttl || (typeof maxAge === 'number'
+  return (typeof maxAge === 'number'
     ? Math.floor(maxAge / 1000)
     : oneDay);
 }
@@ -188,7 +192,7 @@ module.exports = function (session) {
     args.push(jsess);
 
     if (!store.disableTTL) {
-      var ttl = getTTL(store, sess);
+      var ttl = getTTL(store, sess, sid);
       args.push('EX', ttl);
       debug('SET "%s" %s ttl:%s', sid, jsess, ttl);
     } else {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "express-session": "^1.9.1",
     "ioredis": "^2.5.0",
     "istanbul": "^0.4.5",
+    "sinon": "^2.3.4",
     "tape": "^4.2.1"
   },
   "engines": {


### PR DESCRIPTION
Signature is `(store, sess, sid) => number`. Invalid types will now throw.

Added tests to cover existing and new TTL functionality.

### Why?

This is particularly useful for adding custom logic for session duration. For example, we get hit with a lot of automated bots that throw errors on our login form. Those errors are kept in the session, but ideally they should be evicted shortly after the next page is rendered. Without `ttl` as a function, we are unable to make a distinction between short-term and long-term sessions, leading to a lot of unused data in Redis with long expiry times.