### PR TITLE
Dependency Security Issue Fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-redis",
   "description": "Redis session store for Connect",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Marc Harter <wavded@gmail.com>"


### PR DESCRIPTION
Debug needs to be at least version 2.6.9 - when [the ReDoS vulnerability](https://nodesecurity.io/advisories/534) was patched. I went ahead and incremented all the way to 3.1.0 since there are no breaking changes.

Note: all tests and debug tests were run to ensure this didn't break anything. All seems to be good, 64/64 passed on both sets.