### PR TITLE
express-session requires the resave value to be defined

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -17,7 +17,8 @@ var RedisStore = require('connect-redis')(session);
 
 app.use(session({
     store: new RedisStore(options),
-    secret: 'keyboard cat'
+    secret: 'keyboard cat',
+    resave: false
 }));
 ```
 


### PR DESCRIPTION
```
express-session deprecated undefined resave option; provide resave option
```

This makes it easier for people that quickly sets it by providing a good default to copy and paste.