### PR TITLE
Fix issue #219

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -327,6 +327,8 @@ module.exports = function (session) {
     allKeys(store, function (err, keys) {
       if (err) return fn(err);
 
+      if (keys.length === 0) return fn(null,[]);
+
       store.client.mget(keys, function (err, sessions) {
         if (err) return fn(err);
 


### PR DESCRIPTION
When calling the `.all()` method we get error:

`{ ReplyError: ERR wrong number of arguments for 'mget' command at parseError (D:\prj\node_modules\redis-parser\lib\parser.js:193:12) at parseType (D:\prj\node_modules\redis-parser\lib\parser.js:303:14) command: 'MGET', code: 'ERR' }`

Above error is thrown when there are no session keys present in redis.

Redis `MGET` command returns error when `null` or `[]` is passed as argument.

So a check is added before directly passing keys to `MGET` command.

If there are no keys present then `MGET` command is not invoked instead `[]` is returned