### PR TITLE
Corrected session maxAge const path

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ A Redis client is required. An existing client can be passed directly using the 
 
 The following additional params may be included:
 
--	`ttl` Redis session TTL (expiration) in seconds. Defaults to session.maxAge (if set), or one day.
+-	`ttl` Redis session TTL (expiration) in seconds. Defaults to session.cookie.maxAge (if set), or one day.
 	-	This may also be set to a function of the form `(store, sess, sessionID) => number`.
 -	`disableTTL` Disables setting TTL, keys will stay in redis until evicted by other means (overides `ttl`\)
 -	`db` Database index to use. Defaults to Redis's default (0).


### PR DESCRIPTION
Correcting session.maxAge -> session.cookie.maxAge for clarity as express-session does not have a session.maxAge setting.