### PR TITLE
add length method

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -311,6 +311,24 @@ module.exports = function (session) {
     });
   };
 
+  /**
+   * Fetch count of all sessions
+   *
+   * @param {Function} fn
+   * @api public
+   */
+
+  RedisStore.prototype.length = function (fn) {
+    var store = this;
+    if (!fn) fn = noop;
+
+    allKeys(store, function (err, keys) {
+      if (err) return fn(err);
+
+      return fn(null, keys.length);
+    });
+  };
+
 
   /**
    * Fetch all sessions

--- a/test/connect-redis-test.js
+++ b/test/connect-redis-test.js
@@ -26,6 +26,9 @@ var lifecycleTest = P.coroutine(function *(store, t) {
   data = yield store.idsAsync();
   t.deepEqual(['123'], data, '#ids() ok');
 
+  data = yield store.lengthAsync();
+  t.deepEqual(1, data, '#length() ok');
+
   ok = yield store.destroyAsync('123');
   t.equal(ok, 1, '#destroy() ok');
 


### PR DESCRIPTION
Hello, just found that this store doesn't have [this](https://github.com/expressjs/session#storelengthcallback) method.

Is this PR ok, so we could add it?