### PR TITLE
Mention redis-mock in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -58,6 +58,10 @@ Clients other than `node_redis` will work if they support the same interface. Ju
 
 -	[ioredis](https://github.com/luin/ioredis) - adds support for Redis Sentinel and Cluster
 
+#### Testing / Development
+
+You can use [redis-mock](https://github.com/yeahoffline/redis-mock) as the client instead of connecting to an actual redis server for automated testing and development purposes.
+
 FAQ
 ---
 


### PR DESCRIPTION
Following up from #249.

This just mentions redis-mock as an option in the clients section of the readme.