### PR TITLE
Require node_redis conditionally

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -5,7 +5,6 @@
  */
 
 var debug = require('debug')('connect:redis');
-var redis = require('redis');
 var util = require('util');
 var noop = function(){};
 
@@ -76,12 +75,15 @@ module.exports = function (session) {
     // convert to redis connect params
     if (options.client) {
       this.client = options.client;
-    }
-    else if (options.socket) {
-      this.client = redis.createClient(options.socket, options);
-    }
-    else {
-      this.client = redis.createClient(options);
+    } else {
+      var redis = require('redis');
+
+      if (options.socket) {
+        this.client = redis.createClient(options.socket, options);
+      }
+      else {
+        this.client = redis.createClient(options);
+      }
     }
 
     // logErrors


### PR DESCRIPTION
I noticed that `node_redis` is being loaded at all times, even when a custom Redis client (e.g. `ioredis`) is used instead. This PR moves the `require` call so that `node_redis` (and its dependencies) is _only_ pulled in when needed, i.e. when the `client` option is missing, thus leading to a small performance boost.

P.S. I couldn't run the test suite; does it require to have `redis-server` installed on the machine?