### PR TITLE
Fix #251 Add disableTTLResetOnTouch option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,7 @@ The following additional params may be included:
 -	`ttl` Redis session TTL (expiration) in seconds. Defaults to session.cookie.maxAge (if set), or one day.
 	-	This may also be set to a function of the form `(store, sess, sessionID) => number`.
 -	`disableTTL` Disables setting TTL, keys will stay in redis until evicted by other means (overides `ttl`\)
+- `disableTTLResetOnTouch` Disable resetting the TTL when calling 'touch' on a session id (false by default)
 -	`db` Database index to use. Defaults to Redis's default (0).
 -	`pass` Password for Redis authentication
 -	`prefix` Key prefix defaulting to "sess:"

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -108,6 +108,7 @@ module.exports = function (session) {
 
     this.ttl = options.ttl;
     this.disableTTL = options.disableTTL;
+    this.disableTTLResetOnTouch = options.disableTTLResetOnTouch;
 
     if (options.unref) this.client.unref();
 
@@ -244,6 +245,7 @@ module.exports = function (session) {
     var psid = store.prefix + sid;
     if (!fn) fn = noop;
     if (store.disableTTL) return fn();
+    if (store.disableTTLResetOnTouch) return fn();
 
     var ttl = getTTL(store, sess);
 


### PR DESCRIPTION
@wavded I believe this is all that would be needed to fix the issue addressed in #251. I have tested it locally and it is behaving how I initially expected `express-session` to behave with this store.

If I am understanding the purpose of the 'touch' function correctly, `connect-redis` might not need to implement 'touch' at all. But the flag i'm proposing in this PR leaves the code backwards compatible to its current behavior while also allowing the caller to specifically have it on or off.