### PR TITLE
Replace .concat with .push

### DIFF
--- a/test/connect-redis-test.js
+++ b/test/connect-redis-test.js
@@ -169,7 +169,7 @@ test('ttl options', P.coroutine(function *(t) {
 
 function assertSetCalledWith(t, store, sid, data, addl) {
   var args = [store.prefix + sid, store.serializer.stringify(data)];
-  if (Array.isArray(addl)) args = args.concat(addl);
+  if (Array.isArray(addl)) args = args.push(addl);
   t.deepEqual(store.client.set.lastCall.args[0], args, '#.set() called with expected params');
 }
 


### PR DESCRIPTION
Replace .concat() with .push(), it's 945x faster, lol
https://dev.to/uilicious/javascript-array-push-is-945x-faster-than-array-concat-1oki/comments