### PR TITLE
Enabling logging by default; Adding test cases for options.logErrors

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -43,7 +43,7 @@ The following additional params may be included:
 -	`prefix` Key prefix defaulting to "sess:"
 -	`unref` Set `true` to unref the Redis client. **Warning**: this is [an experimental feature](https://github.com/mranney/node_redis#clientunref).
 -	`serializer` An object containing `stringify` and `parse` methods compatible with Javascript's `JSON` to override the serializer used
--	`logErrors` Whether or not to log client errors. (default: `false`\)
+-	`logErrors` Whether or not to log client errors. (default: `true`\)
 	-	If `true`, a default logging function (`console.error`) is provided.
 	-	If a function, it is called anytime an error occurs (useful for custom logging)
 	-	If `false`, no logging occurs.

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -68,6 +68,9 @@ module.exports = function (session) {
 
     this.serializer = options.serializer || JSON;
 
+    this.logErrors = options.logErrors !== undefined ? options.logErrors : true;
+    delete options.logErrors;
+
     if (options.url) {
       options.socket = options.url;
     }
@@ -87,15 +90,16 @@ module.exports = function (session) {
     }
 
     // logErrors
-    if(options.logErrors){
-      // if options.logErrors is function, allow it to override. else provide default logger. useful for large scale deployment
+    if (this.logErrors) {
+      // if this.logErrors is function, allow it to override. else provide default logger. useful for large scale deployment
       // which may need to write to a distributed log
-      if(typeof options.logErrors != 'function'){
-        options.logErrors = function (err) {
+      if (typeof this.logErrors != 'function') {
+        this.logErrors = function (err) {
           console.error('Warning: connect-redis reported a client error: ' + err);
         };
       }
-      this.client.on('error', options.logErrors);
+
+      this.client.on('error', this.logErrors);
     }
 
     if (options.pass) {

--- a/test/connect-redis-test.js
+++ b/test/connect-redis-test.js
@@ -197,4 +197,25 @@ test('serializer', function (t) {
   return lifecycleTest(store, t);
 });
 
+test('logErrors', function (t) {
+  // Default to true, thus using console.error
+  var store = new RedisStore();
+  t.equal(typeof store.logErrors, 'function');
+
+  // Disabled logging
+  store = new RedisStore({
+    logErrors: false,
+  });
+  t.equal(store.logErrors, false);
+
+  // Using custom function
+  var logErrors = function(error) {
+    console.warn('Error caught: ', error);
+  };
+  store = new RedisStore({
+    logErrors,
+  });
+  t.equal(store.logErrors, logErrors);
+});
+
 test('teardown', redisSrv.disconnect);

--- a/test/redis-server.js
+++ b/test/redis-server.js
@@ -8,6 +8,11 @@ exports.connect = function () {
     '--port', port,
     '--loglevel', 'notice',
   ], { stdio: 'inherit' });
+
+  redisSrv.on('error', function (error) {
+    console.log('Error caught spawning the server: ', error);
+  });
+
   return P.delay(1500);
 };
 

--- a/test/redis-server.js
+++ b/test/redis-server.js
@@ -10,7 +10,7 @@ exports.connect = function () {
   ], { stdio: 'inherit' });
 
   redisSrv.on('error', function (error) {
-    console.log('Error caught spawning the server: ', error);
+    console.error('Error caught spawning the server: ', error);
   });
 
   return P.delay(1500);


### PR DESCRIPTION
Relates to [https://github.com/tj/connect-redis/issues/260](https://github.com/tj/connect-redis/issues/260)

While working on a project, we experienced different problems when connecting to our Redis instance, but the errors were silently ignored and not thrown by the library. I think that the error logging should be enabled by default.

Added error handler to the spawn command, because it was throwing an error about any unhandled error events.