### PR TITLE
Fix compatibility issues with ioredis + Cluster

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -217,6 +217,8 @@ module.exports = function (session) {
 
   RedisStore.prototype.destroy = function (sid, fn) {
     debug('DEL "%s"', sid);
+    if (!fn) fn = noop;
+
     if (Array.isArray(sid)) {
       var multi = this.client.multi();
       var prefix = this.prefix;

--- a/test/connect-redis-test.js
+++ b/test/connect-redis-test.js
@@ -63,7 +63,19 @@ test('existing client', function (t) {
 test('io redis client', function (t) {
   var client = ioRedis.createClient(redisSrv.port, 'localhost');
   var store = new RedisStore({ client: client });
-  return lifecycleTest(store, t);
+  return lifecycleTest(store, t).then(function () {
+    t.test('#destroy()', function (p) {
+      var spy = sinon.spy(ioRedis.prototype, 'sendCommand');
+      var sidName = 'randomname';
+      store.destroy(sidName);
+      p.deepEqual(
+        spy.firstCall.args[0].args,
+        [store.prefix + sidName]
+      );
+      spy.restore();
+      p.end();
+    });
+  });
 });
 
 test('options', function (t) {


### PR DESCRIPTION
When calling req.session.destroy() without providing a callback function,
we actually invoke `redis.del(sid, undefined)`. However, ioredis considers
`undefined` as empty strings, which makes the invocation become
`redis.del(sid, "")`, and it will cause errors under cluster mode since
empty string may not belongs to the same slot with `sid`.

Related issue: https://github.com/luin/ioredis/issues/914.