### PR TITLE
V4

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "tabWidth": 2,
-  "semi": true,
+  "semi": false,
   "singleQuote": true,
   "printWidth": 80,
   "trailingComma": "es5"

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require('./lib/connect-redis');
+module.exports = require('./lib/connect-redis')

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -1,365 +1,151 @@
-/*!
- * Connect - Redis
- * Copyright(c) 2012 TJ Holowaychuk <tj@vision-media.ca>
- * MIT Licensed
- */
-var debug = require('debug')('connect:redis');
-var util = require('util');
-var noop = function() {};
-
-/**
- * One day in seconds.
- */
-var oneDay = 86400;
-
-function getTTL(store, sess, sid) {
-  if (typeof store.ttl === 'number' || typeof store.ttl === 'string')
-    return store.ttl;
-  if (typeof store.ttl === 'function') return store.ttl(store, sess, sid);
-  if (store.ttl)
-    throw new TypeError('`store.ttl` must be a number or function.');
-
-  var maxAge = sess.cookie.maxAge;
-  return typeof maxAge === 'number' ? Math.floor(maxAge / 1000) : oneDay;
-}
-
-/**
- * Return the `RedisStore` extending `express`'s session Store.
- *
- * @param {object} express session
- * @return {Function}
- * @api public
- */
-
 module.exports = function(session) {
-  /**
-   * Express's session Store.
-   */
-  var Store = session.Store;
+  const Store = session.Store
+  const noop = () => {}
 
-  /**
-   * Initialize RedisStore with the given `options`.
-   *
-   * @param {Object} options
-   * @api public
-   */
-  function RedisStore(options) {
-    if (!(this instanceof RedisStore)) {
-      throw new TypeError('Cannot call RedisStore constructor as a function');
-    }
-
-    var self = this;
-
-    options = options || {};
-    Store.call(this, options);
-    this.prefix = options.prefix == null ? 'sess:' : options.prefix;
-
-    delete options.prefix;
-
-    this.scanCount = Number(options.scanCount) || 100;
-    delete options.scanCount;
-
-    this.serializer = options.serializer || JSON;
-
-    this.logErrors = options.logErrors !== undefined ? options.logErrors : true;
-    delete options.logErrors;
-
-    if (options.url) {
-      options.socket = options.url;
-    }
-
-    if (options.client) {
-      this.client = options.client;
-    } else {
-      var redis = require('redis');
-
-      if (options.socket) {
-        this.client = redis.createClient(options.socket, options);
-      } else {
-        this.client = redis.createClient(options);
-      }
-    }
-
-    if (this.logErrors) {
-      if (typeof this.logErrors != 'function') {
-        this.logErrors = function(err) {
-          console.error(
-            'Warning: connect-redis reported a client error: ' + err
-          );
-        };
+  class RedisStore extends Store {
+    constructor(options = {}) {
+      super(options)
+      if (!options.client) {
+        throw new Error('A client must be directly provided to the RedisStore')
       }
 
-      this.client.on('error', this.logErrors);
+      this.prefix = options.prefix == null ? 'sess:' : options.prefix
+      this.scanCount = Number(options.scanCount) || 100
+      this.serializer = options.serializer || JSON
+      this.client = options.client
+      this.ttl = options.ttl || 86400 // One day in seconds.
+      this.disableTouch = options.disableTouch || false
     }
 
-    if (options.pass) {
-      this.client.auth(options.pass, function(err) {
-        if (err) {
-          throw err;
-        }
-      });
-    }
+    get(sid, cb = noop) {
+      let key = this.prefix + sid
 
-    this.ttl = options.ttl;
-    this.disableTTL = options.disableTTL;
+      this.client.get(key, (er, data) => {
+        if (er) return cb(er)
+        if (!data) return cb()
 
-    if (options.unref) this.client.unref();
-
-    if ('db' in options) {
-      if (typeof options.db !== 'number') {
-        console.error(
-          'Warning: connect-redis expects a number for the "db" option'
-        );
-      }
-
-      self.client.select(options.db);
-      self.client.on('connect', function() {
-        self.client.select(options.db);
-      });
-    }
-
-    self.client.on('error', function(er) {
-      debug('Redis returned err', er);
-      self.emit('disconnect', er);
-    });
-
-    self.client.on('connect', function() {
-      self.emit('connect');
-    });
-  }
-
-  /**
-   * Inherit from `Store`.
-   */
-  util.inherits(RedisStore, Store);
-
-  /**
-   * Attempt to fetch session by the given `sid`.
-   *
-   * @param {String} sid
-   * @param {Function} fn
-   * @api public
-   */
-  RedisStore.prototype.get = function(sid, fn) {
-    var store = this;
-    var psid = store.prefix + sid;
-    if (!fn) fn = noop;
-    debug('GET "%s"', sid);
-
-    store.client.get(psid, function(er, data) {
-      if (er) return fn(er);
-      if (!data) return fn();
-
-      var result;
-      data = data.toString();
-      debug('GOT %s', data);
-
-      try {
-        result = store.serializer.parse(data);
-      } catch (er) {
-        return fn(er);
-      }
-      return fn(null, result);
-    });
-  };
-
-  /**
-   * Commit the given `sess` object associated with the given `sid`.
-   *
-   * @param {String} sid
-   * @param {Session} sess
-   * @param {Function} fn
-   * @api public
-   */
-  RedisStore.prototype.set = function(sid, sess, fn) {
-    var store = this;
-    var args = [store.prefix + sid];
-    if (!fn) fn = noop;
-
-    try {
-      var jsess = store.serializer.stringify(sess);
-    } catch (er) {
-      return fn(er);
-    }
-
-    args.push(jsess);
-
-    if (!store.disableTTL) {
-      var ttl = getTTL(store, sess, sid);
-      args.push('EX', ttl);
-      debug('SET "%s" %s ttl:%s', sid, jsess, ttl);
-    } else {
-      debug('SET "%s" %s', sid, jsess);
-    }
-
-    store.client.set(args, function(er) {
-      if (er) return fn(er);
-      debug('SET complete');
-      fn.apply(null, arguments);
-    });
-  };
-
-  /**
-   * Destroy the session associated with the given `sid`.
-   *
-   * @param {String} sid
-   * @api public
-   */
-  RedisStore.prototype.destroy = function(sid, fn) {
-    debug('DEL "%s"', sid);
-    if (!fn) fn = noop;
-
-    if (Array.isArray(sid)) {
-      var multi = this.client.multi();
-      var prefix = this.prefix;
-      sid.forEach(function(s) {
-        multi.del(prefix + s);
-      });
-      multi.exec(fn);
-    } else {
-      sid = this.prefix + sid;
-      this.client.del(sid, fn);
-    }
-  };
-
-  /**
-   * Refresh the time-to-live for the session with the given `sid`.
-   *
-   * @param {String} sid
-   * @param {Session} sess
-   * @param {Function} fn
-   * @api public
-   */
-  RedisStore.prototype.touch = function(sid, sess, fn) {
-    var store = this;
-    var psid = store.prefix + sid;
-    if (!fn) fn = noop;
-    if (store.disableTTL) return fn();
-
-    var ttl = getTTL(store, sess);
-
-    debug('EXPIRE "%s" ttl:%s', sid, ttl);
-    store.client.expire(psid, ttl, function(er) {
-      if (er) return fn(er);
-      debug('EXPIRE complete');
-      fn.apply(this, arguments);
-    });
-  };
-
-  /**
-   * Fetch all sessions' Redis keys using non-blocking SCAN command
-   *
-   * @param {Function} fn
-   * @api private
-   */
-  function allKeys(store, cb) {
-    var keysObj = {}; // Use an object to dedupe as scan can return duplicates
-    var pattern = store.prefix + '*';
-    var scanCount = store.scanCount;
-    debug('SCAN "%s"', pattern);
-
-    (function nextBatch(cursorId) {
-      store.client.scan(
-        cursorId,
-        'match',
-        pattern,
-        'count',
-        scanCount,
-        function(err, result) {
-          if (err) return cb(err);
-
-          var nextCursorId = result[0];
-          var keys = result[1];
-
-          debug('SCAN complete (next cursor = "%s")', nextCursorId);
-
-          keys.forEach(function(key) {
-            keysObj[key] = 1;
-          });
-
-          if (nextCursorId != 0) {
-            return nextBatch(nextCursorId);
-          }
-
-          return cb(null, Object.keys(keysObj));
-        }
-      );
-    })(0);
-  }
-
-  /**
-   * Fetch all sessions' ids
-   *
-   * @param {Function} fn
-   * @api public
-   */
-  RedisStore.prototype.ids = function(fn) {
-    var store = this;
-    var prefixLength = store.prefix.length;
-    if (!fn) fn = noop;
-
-    allKeys(store, function(err, keys) {
-      if (err) return fn(err);
-
-      keys = keys.map(function(key) {
-        return key.substr(prefixLength);
-      });
-      return fn(null, keys);
-    });
-  };
-
-  /**
-   * Fetch count of all sessions
-   *
-   * @param {Function} fn
-   * @api public
-   */
-  RedisStore.prototype.length = function(fn) {
-    var store = this;
-    if (!fn) fn = noop;
-
-    allKeys(store, function(err, keys) {
-      if (err) return fn(err);
-
-      return fn(null, keys.length);
-    });
-  };
-
-  /**
-   * Fetch all sessions
-   *
-   * @param {Function} fn
-   * @api public
-   */
-  RedisStore.prototype.all = function(fn) {
-    var store = this;
-    var prefixLength = store.prefix.length;
-    if (!fn) fn = noop;
-
-    allKeys(store, function(err, keys) {
-      if (err) return fn(err);
-
-      if (keys.length === 0) return fn(null, []);
-
-      store.client.mget(keys, function(err, sessions) {
-        if (err) return fn(err);
-
-        var result;
+        let result
         try {
-          result = sessions.map(function(data, index) {
-            data = data.toString();
-            data = store.serializer.parse(data);
-            data.id = keys[index].substr(prefixLength);
-            return data;
-          });
-        } catch (e) {
-          err = e;
+          result = this.serializer.parse(data)
+        } catch (er) {
+          return cb(er)
+        }
+        return cb(null, result)
+      })
+    }
+
+    set(sid, sess, cb = noop) {
+      let args = [this.prefix + sid]
+
+      let value
+      try {
+        value = this.serializer.stringify(sess)
+      } catch (er) {
+        return cb(er)
+      }
+      args.push(value)
+      args.push('EX', this._getTTL(sess))
+
+      this.client.set(args, cb)
+    }
+
+    touch(sid, sess, cb = noop) {
+      if (this.disableTouch) return cb()
+
+      // Since we need to update the expires value on the cookie,
+      // we update the whole session object.
+      this.set(sid, sess, cb)
+    }
+
+    destroy(sid, cb = noop) {
+      let key = this.prefix + sid
+      this.client.del(key, cb)
+    }
+
+    clear(cb = noop) {
+      this._getAllKeys((err, keys) => {
+        if (err) return cb(err)
+        this.client.del(keys, cb)
+      })
+    }
+
+    length(cb = noop) {
+      this._getAllKeys((err, keys) => {
+        if (err) return cb(err)
+        return cb(null, keys.length)
+      })
+    }
+
+    ids(cb = noop) {
+      let prefixLen = this.prefix.length
+
+      this._getAllKeys((err, keys) => {
+        if (err) return cb(err)
+        keys = keys.map(key => key.substr(prefixLen))
+        return cb(null, keys)
+      })
+    }
+
+    all(cb = noop) {
+      let prefixLen = this.prefix.length
+
+      this._getAllKeys((err, keys) => {
+        if (err) return cb(err)
+        if (keys.length === 0) return cb(null, [])
+
+        this.client.mget(keys, (err, sessions) => {
+          if (err) return cb(err)
+
+          let result
+          try {
+            result = sessions.map((data, index) => {
+              data = this.serializer.parse(data)
+              data.id = keys[index].substr(prefixLen)
+              return data
+            })
+          } catch (e) {
+            err = e
+          }
+          return cb(err, result)
+        })
+      })
+    }
+
+    _getTTL(sess) {
+      let ttl
+      if (sess && sess.cookie && sess.cookie.expires) {
+        let ms = Number(new Date(sess.cookie.expires)) - Date.now()
+        ttl = Math.ceil(ms / 1000)
+      } else {
+        ttl = this.ttl
+      }
+      return ttl
+    }
+
+    _getAllKeys(cb = noop) {
+      let pattern = this.prefix + '*'
+      this._scanKeys({}, 0, pattern, this.scanCount, cb)
+    }
+
+    _scanKeys(keys = {}, cursor, pattern, count, cb = noop) {
+      let args = [cursor, 'match', pattern, 'count', count]
+      this.client.scan(args, (err, data) => {
+        if (err) return cb(err)
+
+        let [nextCursorId, scanKeys] = data
+        for (let key of scanKeys) {
+          keys[key] = true
         }
 
-        return fn(err, result);
-      });
-    });
-  };
+        // This can be a string or a number. We check both.
+        if (Number(nextCursorId) !== 0) {
+          return this._scanKeys(keys, nextCursorId, pattern, count, cb)
+        }
 
-  return RedisStore;
-};
+        cb(null, Object.keys(keys))
+      })
+    }
+  }
+
+  return RedisStore
+}

--- a/readme.md
+++ b/readme.md
@@ -7,78 +7,46 @@
 Yarn:
 
 ```sh
-yarn add connect-redis express-session
+yarn add redis connect-redis express-session
 ```
 
 npm:
 
 ```sh
-npm install connect-redis express-session
+npm install redis connect-redis express-session
 ```
 
 ## API
 
 ```js
-var session = require('express-session');
-var RedisStore = require('connect-redis')(session);
+const redis = require('redis')
+const session = require('express-session')
+
+let RedisStore = require('connect-redis')(session)
+let client = redis.createClient()
 
 app.use(
   session({
-    store: new RedisStore(options),
+    store: new RedisStore({ client }),
     secret: 'keyboard cat',
     resave: false,
   })
-);
+)
 ```
 
 ### RedisStore(options)
 
-`RedisStore` will generate a new Redis client (using `node-redis`) given `host`, `port` or `socket` options. You may also provide an existing client using the `client` option. Existing clients must be compatible with the `node-redis` API (e.g. `ioredis` is a popular alternative).
+The `RedisStore` requires an existing Redis client. Any clients compatible with the `node_redis` API will work. See `client` option for more details.
 
 #### Options
 
-##### host
-
-Redis host (default: `localhost`). Ignored when `client` option used.
-
-##### port
-
-Redis port (default: `6379`). Ignored when `client` option used.
-
-##### db
-
-Redis database (default: `0`). Ignored when `client` option used.
-
-##### pass
-
-Password for Redis authentication. Ignored when `client` option used.
-
-##### socket
-
-Redis socket. Ignored when `client` option used.
-
-##### unref
-
-Set `true` to unref the Redis client, allowing Node to shutdown the process if Redis holding open the event loop.. Ignored when `client` option used. **Warning**: this is [an experimental feature](https://github.com/mranney/node_redis#clientunref).
-
-##### logErrors
-
-Log Redis client errors to the console (default: `true`). Ignored when `client` option used.
-
-If you need more explicit control you can provide a custom function instead:
-
-```js
-var logFn = err => {
-  // Log client errors programmatically.
-};
-```
-
 ##### client
 
-An instance of a `node_redis` or `node_redis` compatible client
+An instance of a `node_redis` or a `node_redis` compatible client.
 
-Known compatible alternatives to `node_redis`:
+Known compatible and tested clients:
 
+- [redis](https://github.com/NodeRedis/node_redis)
 - [ioredis](https://github.com/luin/ioredis)
 - [redis-mock](https://github.com/yeahoffline/redis-mock) for testing.
 
@@ -88,21 +56,19 @@ Key prefix in Redis (default: `sess:`)
 
 ##### ttl
 
-Redis session TTL in seconds. (default: `session.cookie.maxAge` if set or one day)
+If the session cookie has a `expires` date, `connect-redis` will use it as the TTL.
 
-If you need more explicit control you can provide a custom function instead:
+Otherwise, it will expire the session using the `ttl` option (default: `86400` seconds or one day).
 
-```js
-var ttlFn = (store, sess, sessionID) => {
-  // Calculate TTL programmatically.
-  return ttl;
-};
-```
+**Note**: The TTL is reset every time a user interacts with the server. You can disable this behavior in _some_ instances by using `disableTouch`.
 
-##### disableTTL
+##### disableTouch
 
-Disables setting a TTL. This means keys will never expire and will stay in Redis until evicted by
-other means (overrides `ttl` option).
+Disables re-saving and resetting the TTL when using `touch` (default: `false`)
+
+The `express-session` package uses `touch` to signal to the store that the user has interacted with the session but hasn't changed anything in its data. Typically, this helps keep the users session alive if session changes are infrequent but you may want to disable it to cut down the extra calls or to prevent users from keeping sessions open too long.
+
+Ref: https://github.com/expressjs/session#storetouchsid-session-callback
 
 ##### serializer
 
@@ -110,8 +76,8 @@ The encoder/decoder to use when storing and retrieving session data from Redis (
 
 ```ts
 interface Serializer {
-  parse(string): object;
-  stringify(object): string;
+  parse(string): object
+  stringify(object): string
 }
 ```
 
@@ -121,18 +87,24 @@ Value used for _count_ parameter in [Redis `SCAN` command](https://redis.io/comm
 
 ## FAQ
 
+#### How to a log Redis errors?
+
+```js
+client.on('error', console.error)
+```
+
 #### How do I handle lost connections to Redis?
 
 By default, the `node_redis` client will [auto-reconnect](https://github.com/mranney/node_redis#overloading) on lost connections. But requests may come in during that time. In Express, one way you can handle this scenario is including a "session check":
 
 ```js
-app.use(session(/* setup session here */));
+app.use(session(/* setup session here */))
 app.use(function(req, res, next) {
   if (!req.session) {
-    return next(new Error('oh no')); // handle error
+    return next(new Error('oh no')) // handle error
   }
-  next(); // otherwise continue
-});
+  next() // otherwise continue
+})
 ```
 
 If you want to retry, here is [another option](https://github.com/expressjs/session/issues/99#issuecomment-63853989).

--- a/test/connect-redis-test.js
+++ b/test/connect-redis-test.js
@@ -1,272 +1,98 @@
-var test = require('blue-tape');
-var redisSrv = require('./redis-server');
-var session = require('express-session');
-var RedisStore = require('../')(session);
-var redis = require('redis');
-var ioRedis = require('ioredis');
-var redisMock = require('redis-mock');
-var sinon = require('sinon');
-
-test('setup', redisSrv.connect);
-
-test('defaults', function(t) {
-  var store = new RedisStore();
-  t.equal(store.prefix, 'sess:', 'defaults to sess:');
-  t.notOk(store.ttl, 'ttl not set');
-  t.notOk(store.disableTTL, 'disableTTL not set');
-  t.ok(store.client, 'creates client');
-
-  store.client.end(false);
-  t.end();
-});
-
-test('minimal', t => {
-  t.throws(RedisStore, TypeError, 'constructor not callable as function');
-  var store = new RedisStore({ port: redisSrv.port });
-  return lifecycleTest(store, t);
-});
-
-test('options', function(t) {
-  var store = new RedisStore({
-    host: 'localhost',
-    port: redisSrv.port,
-    prefix: 'tobi',
-    ttl: 1000,
-    disableTTL: true,
-    db: 1,
-    scanCount: 32,
-    unref: true,
-    pass: 'secret',
-  });
-
-  t.equal(store.prefix, 'tobi', 'uses provided prefix');
-  t.equal(store.ttl, 1000, 'ttl set');
-  t.ok(store.disableTTL, 'disableTTL set');
-  t.ok(store.client, 'creates client');
-  t.equal(
-    store.client.address,
-    'localhost:' + redisSrv.port,
-    'sets host and port'
-  );
-  t.equal(store.scanCount, 32, 'sets scan count');
-
-  var socketStore = new RedisStore({ socket: 'word' });
-  t.equal(socketStore.client.address, 'word', 'sets socket address');
-  socketStore.client.end(false);
-
-  var urlStore = new RedisStore({ url: 'redis://127.0.0.1:8888' });
-  t.equal(urlStore.client.address, '127.0.0.1:8888', 'sets url address');
-  urlStore.client.end(false);
-
-  var hostNoPort = new RedisStore({ host: 'host' });
-  t.equal(hostNoPort.client.address, 'host:6379', 'sets default port');
-  hostNoPort.client.end(false);
-
-  return lifecycleTest(store, t);
-});
-
-test('ttl options', async t => {
-  var store = new RedisStore({ port: redisSrv.port });
-  var setFn = p(store, 'set');
-
-  var sid = '123';
-  var data, ok;
-  sinon.stub(store.client, 'set').callsArgWith(1, null, 'OK');
-
-  // Basic (one day)
-  data = { cookie: {}, name: 'tj' };
-  ok = await setFn(sid, data);
-  t.equal(ok, 'OK', '#set() ok');
-  assertSetCalledWith(t, store, sid, data, ['EX', 86400]);
-
-  // maxAge in cookie
-  data = { cookie: { maxAge: 2000 }, name: 'tj' };
-  ok = await setFn(sid, data);
-  t.equal(ok, 'OK', '#set() ok');
-  assertSetCalledWith(t, store, sid, data, ['EX', 2]);
-
-  // Floors maxage
-  data = { cookie: { maxAge: 2500 }, name: 'tj' };
-  ok = await setFn(sid, data);
-  t.equal(ok, 'OK', '#set() ok');
-  assertSetCalledWith(t, store, sid, data, ['EX', 2]);
-
-  // store.disableTTL
-  store.disableTTL = true;
-  data = { cookie: {}, name: 'tj' };
-  ok = await setFn(sid, data);
-  t.equal(ok, 'OK', '#set() ok');
-  assertSetCalledWith(t, store, sid, data);
-  store.disableTTL = false;
-
-  // store.ttl: number
-  store.ttl = 50;
-  data = { cookie: {}, name: 'tj' };
-  ok = await setFn(sid, data);
-  t.equal(ok, 'OK', '#set() ok');
-  assertSetCalledWith(t, store, sid, data, ['EX', 50]);
-  store.ttl = null;
-
-  // store.ttl: function
-  store.ttl = sinon.stub().returns(200);
-  data = { cookie: {}, name: 'tj' };
-  ok = await setFn(sid, data);
-  t.equal(ok, 'OK', '#set() ok');
-  assertSetCalledWith(t, store, sid, data, ['EX', 200]);
-  t.ok(store.ttl.called, 'TTL fn was called');
-  t.deepEqual(store.ttl.firstCall.args, [store, data, sid]);
-  store.ttl = null;
-
-  // store.ttl: string (invalid)
-  store.ttl = {};
-  data = { cookie: {}, name: 'tj' };
-  try {
-    ok = await setFn(sid, data);
-    t.ok(false, '#set() should throw with bad TTL');
-  } catch (e) {
-    t.ok(
-      /must be a number or function/i.test(e.message),
-      'bad TTL type throws error'
-    );
-  }
-  store.ttl = null;
-  store.client.end(false);
-});
-
-test('node_redis client', t => {
-  var client = redis.createClient(redisSrv.port, 'localhost');
-  var store = new RedisStore({ client: client });
-  return lifecycleTest(store, t);
-});
-
-test('ioredis client', async t => {
-  var client = ioRedis.createClient(redisSrv.port, 'localhost');
-  var store = new RedisStore({ client: client });
-  await lifecycleTest(store, t);
-  client.disconnect();
-});
-
-test('redis-mock client', async t => {
-  var client = redisMock.createClient();
-  var store = new RedisStore({ client: client });
-  await lifecycleTest(store, t);
-});
-
-test('interups', async t => {
-  var store = new RedisStore({ port: redisSrv.port, connect_timeout: 500 });
-  store.client.end(false);
-  try {
-    await p(store, 'set')('123', {
-      cookie: { maxAge: 2000 },
-      name: 'tj',
-    });
-    t.fail();
-  } catch (err) {
-    t.pass();
-  }
-});
-
-test('serializer', function(t) {
-  var serializer = {
-    stringify: function() {
-      return 'XXX' + JSON.stringify.apply(JSON, arguments);
-    },
-    parse: function(x) {
-      t.ok(x.match(/^XXX/));
-      return JSON.parse(x.substring(3));
-    },
-  };
-  t.equal(serializer.stringify('UnitTest'), 'XXX"UnitTest"');
-  t.equal(serializer.parse(serializer.stringify('UnitTest')), 'UnitTest');
-
-  var store = new RedisStore({ port: redisSrv.port, serializer: serializer });
-  return lifecycleTest(store, t);
-});
-
-test('logErrors', function(t) {
-  // Default to true, thus using console.error
-  var store = new RedisStore();
-  t.equal(typeof store.logErrors, 'function');
-  store.client.end(false);
-
-  // Disabled logging
-  store = new RedisStore({ logErrors: false });
-  t.equal(store.logErrors, false);
-  store.client.end(false);
-
-  // Using custom function
-  var logErrors = function(error) {
-    console.warn('Error caught: ', error);
-  };
-  store = new RedisStore({ logErrors });
-  t.equal(store.logErrors, logErrors);
-  store.client.end(false);
-  t.end();
-});
-
-test('teardown', redisSrv.disconnect);
-
-async function lifecycleTest(store, t) {
-  let table = [
-    {
-      method: 'set',
-      in: ['123', { cookie: { maxAge: 2000 }, name: 'tj' }],
-      out: 'OK',
-    },
-    {
-      method: 'get',
-      in: ['123'],
-      out: { cookie: { maxAge: 2000 }, name: 'tj' },
-    },
-    {
-      method: 'set',
-      in: ['123', { cookie: { maxAge: undefined } }],
-      out: 'OK',
-    },
-    {
-      method: 'all',
-      in: [],
-      out: [{ id: '123', cookie: {} }],
-    },
-    {
-      method: 'ids',
-      in: [],
-      out: ['123'],
-    },
-    {
-      method: 'length',
-      in: [],
-      out: 1,
-    },
-    {
-      method: 'destroy',
-      in: ['123'],
-      out: 1,
-    },
-  ];
-
-  for (let tt of table) {
-    let out = await p(store, tt.method)(...tt.in);
-    t.deepEqual(out, tt.out);
-  }
-
-  store.client.end(false);
-}
-
-function assertSetCalledWith(t, store, sid, data, addl) {
-  var args = [store.prefix + sid, store.serializer.stringify(data)];
-  if (Array.isArray(addl)) args = args.concat(addl);
-  t.deepEqual(
-    store.client.set.lastCall.args[0],
-    args,
-    '#.set() called with expected params'
-  );
-}
+let test = require('blue-tape')
+let redisSrv = require('../test/redis-server')
+let session = require('express-session')
+let RedisStore = require('../')(session)
+let redis = require('redis')
+var ioRedis = require('ioredis')
+var redisMock = require('redis-mock')
 
 var p = (ctx, method) => (...args) =>
   new Promise((resolve, reject) => {
     ctx[method](...args, (err, d) => {
-      if (err) reject(err);
-      resolve(d);
-    });
-  });
+      if (err) reject(err)
+      resolve(d)
+    })
+  })
+
+test('setup', redisSrv.connect)
+
+test('defaults', async t => {
+  t.throws(() => new RedisStore(), 'client is required')
+
+  var client = redis.createClient(redisSrv.port, 'localhost')
+  var store = new RedisStore({ client })
+
+  t.equal(store.client, client, 'stores client')
+  t.equal(store.prefix, 'sess:', 'defaults to sess:')
+  t.equal(store.ttl, 86400, 'defaults to one day')
+  t.equal(store.scanCount, 100, 'defaults SCAN count to 100')
+  t.equal(store.serializer, JSON, 'defaults to JSON serialization')
+  t.equal(store.disableTouch, false, 'defaults to having `touch` enabled')
+  client.end(false)
+})
+
+test('node_redis', async t => {
+  var client = redis.createClient(redisSrv.port, 'localhost')
+  var store = new RedisStore({ client })
+  await lifecycleTest(store, t)
+  client.end(false)
+})
+
+test('ioredis', async t => {
+  var client = ioRedis.createClient(redisSrv.port, 'localhost')
+  var store = new RedisStore({ client })
+  await lifecycleTest(store, t)
+  client.disconnect()
+})
+
+test('redis-mock client', async t => {
+  var client = redisMock.createClient()
+  var store = new RedisStore({ client })
+  await lifecycleTest(store, t)
+})
+
+test('teardown', redisSrv.disconnect)
+
+async function lifecycleTest(store, t) {
+  let res = await p(store, 'set')('123', { foo: 'bar' })
+  t.equal(res, 'OK', 'set value')
+
+  res = await p(store, 'get')('123')
+  t.same(res, { foo: 'bar' }, 'get value')
+
+  res = await p(store.client, 'ttl')('sess:123')
+  t.ok(res >= 86399, 'check one day ttl')
+
+  let ttl = 60
+  let expires = new Date(Date.now() + ttl * 1000).toISOString()
+  res = await p(store, 'set')('456', { cookie: { expires } })
+  t.equal(res, 'OK', 'set cookie expires')
+
+  res = await p(store.client, 'ttl')('sess:456')
+  t.ok(res <= 60, 'check expires ttl')
+
+  res = await p(store, 'length')()
+  t.equal(res, 2, 'stored two keys length')
+
+  res = await p(store, 'ids')()
+  t.same(res, ['123', '456'], 'stored two keys ids')
+
+  res = await p(store, 'all')()
+  t.same(
+    res,
+    [{ id: '123', foo: 'bar' }, { id: '456', cookie: { expires } }],
+    'stored two keys data'
+  )
+
+  res = await p(store, 'destroy')('456')
+  t.equal(res, 1, 'destroyed one')
+
+  res = await p(store, 'length')()
+  t.equal(res, 1, 'one key remains')
+
+  res = await p(store, 'clear')()
+  t.equal(res, 1, 'cleared remaining key')
+
+  res = await p(store, 'length')()
+  t.equal(res, 0, 'no key remains')
+}

--- a/test/redis-server.js
+++ b/test/redis-server.js
@@ -1,21 +1,21 @@
-var spawn = require('child_process').spawn;
-var redisSrv;
-var port = (exports.port = 18543);
+const spawn = require('child_process').spawn
+const port = (exports.port = 18543)
+let redisSrv
 
 exports.connect = () =>
   new Promise((resolve, reject) => {
     redisSrv = spawn('redis-server', ['--port', port, '--loglevel', 'notice'], {
       stdio: 'inherit',
-    });
+    })
 
     redisSrv.on('error', function(err) {
-      reject(new Error('Error caught spawning the server:' + err.message));
-    });
+      reject(new Error('Error caught spawning the server:' + err.message))
+    })
 
-    setTimeout(resolve, 1500);
-  });
+    setTimeout(resolve, 1500)
+  })
 
 exports.disconnect = function() {
-  redisSrv.kill('SIGKILL');
-  return Promise.resolve();
-};
+  redisSrv.kill('SIGKILL')
+  return Promise.resolve()
+}


### PR DESCRIPTION
Goals:

  - Use slightly more modern JavaScript, targeting Node 8 and above.
  - Switch to using `cookie.expires` for TTL like `connect-mongo` does.
  - Remove the embedded node_redis client, a client must be provided.
  - Remove all embedded client options that are no longer needed.
  - Clearer documentation around TTLs.
  - Add `clear` method to support the full `express-session` API.
  - Remove multi-session `destroy` usage to conform with the API.

Non-goals:

  - Maintain backwards compatibility.