### PR TITLE
peerDependencies to optionalDependencies (package.json)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "git@github.com:visionmedia/connect-redis.git"
   },
-  "peerDependencies": {
+  "optionalDependencies": {
     "ioredis": "^4.10.0",
     "redis": "^2.8.0",
     "redis-mock": "^0.46.0"


### PR DESCRIPTION
optionalDependencies dont spill a bunch of warnings on the screen. I use **ioredis** and it's reminding me to always install **redis** and **redis-mock.** every time I run **yarn upgrade --latest**.


**optionalDependencies**
Optional dependencies are just that: optional. If they fail to install, Yarn will still say the install process was successful.This is useful for dependencies that won’t necessarily work on every machine and you have a fallback plan in case they are not installed (e.g. Watchman).
https://yarnpkg.com/lang/en/docs/dependency-types/
