### PR TITLE
dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,6 @@
     "type": "git",
     "url": "git@github.com:visionmedia/connect-redis.git"
   },
-  "optionalDependencies": {
-    "ioredis": "^4.10.0",
-    "redis": "^2.8.0",
-    "redis-mock": "^0.46.0"
-  },
   "devDependencies": {
     "blue-tape": "^1.0.0",
     "bluebird": "^3.5.5",


### PR DESCRIPTION
with peerDependencies or optionalDependecies set, all three packages: ioredis, redis and redis-mock are included when one installs connect-redis.  Instead, shouldn't we just not define and dependencies at all?