### PR TITLE
Easier to skim read and understand

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -25,11 +25,11 @@ const redis = require('redis')
 const session = require('express-session')
 
 let RedisStore = require('connect-redis')(session)
-let client = redis.createClient()
+let redisClient = redis.createClient()
 
 app.use(
   session({
-    store: new RedisStore({ client }),
+    store: new RedisStore({ client: redisClient }),
     secret: 'keyboard cat',
     resave: false,
   })


### PR DESCRIPTION
Although this change increases the number of characters in the example, it's easier to see the option requires a "client" key without reading through the options further down.