### PR TITLE
Fix loading of all keys for large databases

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -110,11 +110,13 @@ module.exports = function(session) {
 
           let result
           try {
-            result = sessions.map((data, index) => {
+            result = sessions.reduce((accum, data, index) => {
+              if (!data) return accum
               data = this.serializer.parse(data)
               data.id = keys[index].substr(prefixLen)
-              return data
-            })
+              accum.push(data)
+              return accum
+            }, [])
           } catch (e) {
             err = e
           }


### PR DESCRIPTION
Since getting a list of keys is asynchronous from getting a value of a single key, there're situations, when key no longer exists in the database, so the script will throw because of data being null. This fix ensures we skip null values.