### PR TITLE
chore: bump redis from 3.0.2 -> 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ioredis": "^4.17.1",
     "nyc": "^15.0.1",
     "prettier": "^2.0.5",
-    "redis": "^3.0.2",
+    "redis": "^3.1.2",
     "redis-mock": "^0.56.3"
   },
   "engines": {


### PR DESCRIPTION
https://github.com/NodeRedis/node-redis/security/advisories/GHSA-35q2-47q7-3pc3

Contributes-to: tj/connect-redis#323