### PR TITLE
Support npm Node Redis v4

### DIFF
--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -31,8 +31,9 @@ module.exports = function (session) {
     get(sid, cb = noop, showTombs = false) {
       let key = this.prefix + sid
 
-      this.client.GET(key)
-        .then(data => {
+      this.client
+        .GET(key)
+        .then((data) => {
           if (!data) {
             cb()
             return
@@ -51,7 +52,7 @@ module.exports = function (session) {
           }
           cb(null, result)
         })
-        .catch(err => {
+        .catch((err) => {
           cb(err)
         })
     }
@@ -83,12 +84,13 @@ module.exports = function (session) {
           }
 
           if (ttl > 0) {
-            this.client.sendCommand(args)
-              .then(r => {
-                cb()
+            this.client
+              .sendCommand(args)
+              .then((r) => {
+                cb(null, r)
               })
-              .catch(err => {
-                cb()
+              .catch((err) => {
+                cb(err)
               })
           } else {
             // If the resulting TTL is negative we can delete / destroy the key
@@ -102,23 +104,25 @@ module.exports = function (session) {
     touch(sid, sess, cb = noop) {
       if (this.disableTouch || this.disableTTL) return cb()
       let key = this.prefix + sid
-      this.client.EXPIRE(key, this._getTTL(sess))
-        .then(ret => {
+      this.client
+        .EXPIRE(key, this._getTTL(sess))
+        .then((ret) => {
           if (ret !== 1) return cb(null, 'EXPIRED')
           return cb(null, 'OK')
         })
-        .catch(err => {
+        .catch((err) => {
           return cb(err)
         })
     }
 
     destroy(sid, cb = noop) {
       let key = this.prefix + sid
-      this.client.SET([key, TOMBSTONE, 'EX', 300])
-        .then(r => {
-          cb(1)
+      this.client
+        .sendCommand(['SET', key, TOMBSTONE, 'EX', '300'])
+        .then((r) => {
+          cb(r)
         })
-        .catch(err => {
+        .catch((err) => {
           cb(err, 1)
         })
     }
@@ -126,11 +130,12 @@ module.exports = function (session) {
     clear(cb = noop) {
       this._getAllKeys((err, keys) => {
         if (err) return cb(err)
-        this.client.DEL(keys)
-          .then(r => {
-            cb()
+        this.client
+          .DEL(keys)
+          .then((r) => {
+            cb(r)
           })
-          .catch(err => {
+          .catch((err) => {
             cb(err)
           })
       })
@@ -160,8 +165,9 @@ module.exports = function (session) {
         if (err) return cb(err)
         if (keys.length === 0) return cb(null, [])
 
-        this.client.MGET(keys)
-          .then(sessions => {
+        this.client
+          .MGET(keys)
+          .then((sessions) => {
             let result
             try {
               result = sessions.reduce((accum, data, index) => {
@@ -176,7 +182,7 @@ module.exports = function (session) {
             }
             return cb(err, result)
           })
-          .catch(err => {
+          .catch((err) => {
             return cb(err)
           })
       })
@@ -191,7 +197,7 @@ module.exports = function (session) {
         ttl = this.ttl
       }
       // v4 cast to string
-      return ''+ttl
+      return '' + ttl
     }
 
     _getAllKeys(cb = noop) {
@@ -201,8 +207,9 @@ module.exports = function (session) {
 
     _scanKeys(keys = {}, cursor, pattern, count, cb = noop) {
       let args = [cursor, 'match', pattern, 'count', count]
-      this.client.SCAN(args)
-        .then(data => {
+      this.client
+        .SCAN(args)
+        .then((data) => {
           let [nextCursorId, scanKeys] = data
           for (let key of scanKeys) {
             keys[key] = true
@@ -215,8 +222,8 @@ module.exports = function (session) {
 
           cb(null, Object.keys(keys))
         })
-        .catch(err => {
-          return cb(err);
+        .catch((err) => {
+          return cb(err)
         })
     }
   }

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -31,19 +31,31 @@ module.exports = function (session) {
     get(sid, cb = noop, showTombs = false) {
       let key = this.prefix + sid
 
-      this.client.get(key, (err, data) => {
-        if (err) return cb(err)
-        if (!data) return cb()
-        if (data === TOMBSTONE) return cb(null, showTombs ? data : undefined)
+      console.log(`Client is GET ${key}`);
+      this.client.GET(key)
+        .then(data => {
+          console.log('CLIENT IS GOTTED', data);
+          if (!data) {
+            cb()
+            return
+          }
+          if (data === TOMBSTONE) {
+            cb(null, showTombs ? data : undefined)
+            return
+          }
 
-        let result
-        try {
-          result = this.serializer.parse(data)
-        } catch (err) {
-          return cb(err)
-        }
-        return cb(null, result)
-      })
+          let result
+          try {
+            result = this.serializer.parse(data)
+          } catch (err) {
+            cb(err)
+            return
+          }
+          cb(null, result)
+        })
+        .catch(err => {
+          cb(err)
+        })
     }
 
     set(sid, sess, cb = noop) {
@@ -55,7 +67,7 @@ module.exports = function (session) {
           } else if (oldSess && oldSess.lastModified !== sess.lastModified) {
             sess = mergeDeep(oldSess, sess)
           }
-          let args = [this.prefix + sid]
+          let args = ['SET', this.prefix + sid]
           let value
           sess.lastModified = Date.now()
           try {
@@ -73,7 +85,19 @@ module.exports = function (session) {
           }
 
           if (ttl > 0) {
-            this.client.set(args, cb)
+
+            console.log(args);
+
+      console.log(`Client is SET ${args}`);
+            this.client.sendCommand(args)
+              .then(r => {
+                console.log('Did a set', r);
+                cb()
+              })
+              .catch(err => {
+                console.log('Did a set err', err);
+                cb()
+              })
           } else {
             // If the resulting TTL is negative we can delete / destroy the key
             this.destroy(sid, cb)
@@ -86,24 +110,40 @@ module.exports = function (session) {
     touch(sid, sess, cb = noop) {
       if (this.disableTouch || this.disableTTL) return cb()
       let key = this.prefix + sid
-      this.client.expire(key, this._getTTL(sess), (err, ret) => {
-        if (err) return cb(err)
-        if (ret !== 1) return cb(null, 'EXPIRED')
-        cb(null, 'OK')
-      })
+      console.log(`Client is EXPIRE ${key}`);
+      this.client.EXPIRE(key, this._getTTL(sess))
+        .then(ret => {
+          if (ret !== 1) return cb(null, 'EXPIRED')
+          return cb(null, 'OK')
+        })
+        .catch(err => {
+          return cb(err)
+        })
     }
 
     destroy(sid, cb = noop) {
       let key = this.prefix + sid
-      this.client.set([key, TOMBSTONE, 'EX', 300], (err) => {
-        cb(err, 1)
-      })
+      console.log(`Client is SET ${key}`);
+      this.client.SET([key, TOMBSTONE, 'EX', 300])
+        .then(r => {
+          cb(1)
+        })
+        .catch(err => {
+          cb(err, 1)
+        })
     }
 
     clear(cb = noop) {
       this._getAllKeys((err, keys) => {
         if (err) return cb(err)
-        this.client.del(keys, cb)
+      console.log(`Client is DEL ${key}`);
+        this.client.DEL(keys)
+          .then(r => {
+            cb()
+          })
+          .catch(err => {
+            cb(err)
+          })
       })
     }
 
@@ -131,23 +171,26 @@ module.exports = function (session) {
         if (err) return cb(err)
         if (keys.length === 0) return cb(null, [])
 
-        this.client.mget(keys, (err, sessions) => {
-          if (err) return cb(err)
-
-          let result
-          try {
-            result = sessions.reduce((accum, data, index) => {
-              if (!data || data === TOMBSTONE) return accum
-              data = this.serializer.parse(data)
-              data.id = keys[index].substr(prefixLen)
-              accum.push(data)
-              return accum
-            }, [])
-          } catch (e) {
-            err = e
-          }
-          return cb(err, result)
-        })
+        console.log(`Client is MGET ${keys}`);
+        this.client.MGET(keys)
+          .then(sessions => {
+            let result
+            try {
+              result = sessions.reduce((accum, data, index) => {
+                if (!data || data === TOMBSTONE) return accum
+                data = this.serializer.parse(data)
+                data.id = keys[index].substr(prefixLen)
+                accum.push(data)
+                return accum
+              }, [])
+            } catch (e) {
+              err = e
+            }
+            return cb(err, result)
+          })
+          .catch(err => {
+            return cb(err)
+          })
       })
     }
 
@@ -159,7 +202,8 @@ module.exports = function (session) {
       } else {
         ttl = this.ttl
       }
-      return ttl
+      // v4 cast to string
+      return ''+ttl
     }
 
     _getAllKeys(cb = noop) {
@@ -169,21 +213,24 @@ module.exports = function (session) {
 
     _scanKeys(keys = {}, cursor, pattern, count, cb = noop) {
       let args = [cursor, 'match', pattern, 'count', count]
-      this.client.scan(args, (err, data) => {
-        if (err) return cb(err)
+      console.log(`Client is SCAN ${args}`);
+      this.client.SCAN(args)
+        .then(data => {
+          let [nextCursorId, scanKeys] = data
+          for (let key of scanKeys) {
+            keys[key] = true
+          }
 
-        let [nextCursorId, scanKeys] = data
-        for (let key of scanKeys) {
-          keys[key] = true
-        }
+          // This can be a string or a number. We check both.
+          if (Number(nextCursorId) !== 0) {
+            return this._scanKeys(keys, nextCursorId, pattern, count, cb)
+          }
 
-        // This can be a string or a number. We check both.
-        if (Number(nextCursorId) !== 0) {
-          return this._scanKeys(keys, nextCursorId, pattern, count, cb)
-        }
-
-        cb(null, Object.keys(keys))
-      })
+          cb(null, Object.keys(keys))
+        })
+        .catch(err => {
+          return cb(err);
+        })
     }
   }
 

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -31,10 +31,8 @@ module.exports = function (session) {
     get(sid, cb = noop, showTombs = false) {
       let key = this.prefix + sid
 
-      console.log(`Client is GET ${key}`);
       this.client.GET(key)
         .then(data => {
-          console.log('CLIENT IS GOTTED', data);
           if (!data) {
             cb()
             return
@@ -85,17 +83,11 @@ module.exports = function (session) {
           }
 
           if (ttl > 0) {
-
-            console.log(args);
-
-      console.log(`Client is SET ${args}`);
             this.client.sendCommand(args)
               .then(r => {
-                console.log('Did a set', r);
                 cb()
               })
               .catch(err => {
-                console.log('Did a set err', err);
                 cb()
               })
           } else {
@@ -110,7 +102,6 @@ module.exports = function (session) {
     touch(sid, sess, cb = noop) {
       if (this.disableTouch || this.disableTTL) return cb()
       let key = this.prefix + sid
-      console.log(`Client is EXPIRE ${key}`);
       this.client.EXPIRE(key, this._getTTL(sess))
         .then(ret => {
           if (ret !== 1) return cb(null, 'EXPIRED')
@@ -123,7 +114,6 @@ module.exports = function (session) {
 
     destroy(sid, cb = noop) {
       let key = this.prefix + sid
-      console.log(`Client is SET ${key}`);
       this.client.SET([key, TOMBSTONE, 'EX', 300])
         .then(r => {
           cb(1)
@@ -136,7 +126,6 @@ module.exports = function (session) {
     clear(cb = noop) {
       this._getAllKeys((err, keys) => {
         if (err) return cb(err)
-      console.log(`Client is DEL ${key}`);
         this.client.DEL(keys)
           .then(r => {
             cb()
@@ -171,7 +160,6 @@ module.exports = function (session) {
         if (err) return cb(err)
         if (keys.length === 0) return cb(null, [])
 
-        console.log(`Client is MGET ${keys}`);
         this.client.MGET(keys)
           .then(sessions => {
             let result
@@ -213,7 +201,6 @@ module.exports = function (session) {
 
     _scanKeys(keys = {}, cursor, pattern, count, cb = noop) {
       let args = [cursor, 'match', pattern, 'count', count]
-      console.log(`Client is SCAN ${args}`);
       this.client.SCAN(args)
         .then(data => {
           let [nextCursorId, scanKeys] = data

--- a/lib/connect-redis.js
+++ b/lib/connect-redis.js
@@ -32,7 +32,7 @@ module.exports = function (session) {
       let key = this.prefix + sid
 
       this.client
-        .GET(key)
+        .get(key)
         .then((data) => {
           if (!data) {
             cb()
@@ -105,7 +105,7 @@ module.exports = function (session) {
       if (this.disableTouch || this.disableTTL) return cb()
       let key = this.prefix + sid
       this.client
-        .EXPIRE(key, this._getTTL(sess))
+        .expire(key, this._getTTL(sess))
         .then((ret) => {
           if (ret !== 1) return cb(null, 'EXPIRED')
           return cb(null, 'OK')
@@ -131,9 +131,9 @@ module.exports = function (session) {
       this._getAllKeys((err, keys) => {
         if (err) return cb(err)
         this.client
-          .DEL(keys)
+          .del(keys)
           .then((r) => {
-            cb(r)
+            cb(null, r)
           })
           .catch((err) => {
             cb(err)
@@ -166,7 +166,7 @@ module.exports = function (session) {
         if (keys.length === 0) return cb(null, [])
 
         this.client
-          .MGET(keys)
+          .mget(keys)
           .then((sessions) => {
             let result
             try {
@@ -202,25 +202,25 @@ module.exports = function (session) {
 
     _getAllKeys(cb = noop) {
       let pattern = this.prefix + '*'
-      this._scanKeys({}, 0, pattern, this.scanCount, cb)
+      this._scanKeys([], '0', pattern, this.scanCount, cb)
     }
 
-    _scanKeys(keys = {}, cursor, pattern, count, cb = noop) {
-      let args = [cursor, 'match', pattern, 'count', count]
+    _scanKeys(keys = [], cursor, pattern, count, cb = noop) {
       this.client
-        .SCAN(args)
+        .scan(cursor, {
+          'MATCH': pattern,
+          'COUNT': count
+        })
         .then((data) => {
-          let [nextCursorId, scanKeys] = data
-          for (let key of scanKeys) {
-            keys[key] = true
-          }
+          keys = keys.concat(data.keys);
 
           // This can be a string or a number. We check both.
-          if (Number(nextCursorId) !== 0) {
+          let nextCursorId = Number(data.cursor);
+          if (nextCursorId !== 0) {
             return this._scanKeys(keys, nextCursorId, pattern, count, cb)
           }
 
-          cb(null, Object.keys(keys))
+          cb(null, keys)
         })
         .catch((err) => {
           return cb(err)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mockdate": "^2.0.5",
     "nyc": "^15.0.1",
     "prettier": "^2.0.5",
-    "redis": "^3.1.2",
+    "redis": "^4.0.0",
     "redis-mock": "^0.56.3"
   },
   "engines": {

--- a/readme.md
+++ b/readme.md
@@ -26,6 +26,7 @@ const session = require('express-session')
 
 let RedisStore = require('connect-redis')(session)
 let redisClient = redis.createClient()
+redisClient.connect();
 
 app.use(
   session({

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ const session = require('express-session')
 
 let RedisStore = require('connect-redis')(session)
 let redisClient = redis.createClient()
-redisClient.connect();
+redisClient.connect()
 
 app.use(
   session({

--- a/test/connect-redis-test.js
+++ b/test/connect-redis-test.js
@@ -25,6 +25,7 @@ test('defaults', async (t) => {
   t.throws(() => new RedisStore(), 'client is required')
 
   var client = redis.createClient(redisSrv.port, 'localhost')
+  await client.connect();
   var store = new RedisStore({ client })
 
   t.equal(store.client, client, 'stores client')
@@ -34,14 +35,15 @@ test('defaults', async (t) => {
   t.equal(store.serializer, JSON, 'defaults to JSON serialization')
   t.equal(store.disableTouch, false, 'defaults to having `touch` enabled')
   t.equal(store.disableTTL, false, 'defaults to having `ttl` enabled')
-  client.end(false)
+  client.disconnect()
 })
 
 test('node_redis', async (t) => {
   var client = redis.createClient(redisSrv.port, 'localhost')
+  await client.connect();
   var store = new RedisStore({ client })
   await lifecycleTest(store, t)
-  client.end(false)
+  client.disconnect()
 })
 
 test('ioredis', async (t) => {


### PR DESCRIPTION
This should fix #336 

Makes connect redis compatible with node redis v4

TLDR:
- fix all the redis calls to their upper case NAMES
- fix all the redis calls to promises (then/catch version)
- fix TTL to a string in the `set` function and call `sendCommand` instead of `set` as they have changed the args/array passing method too much
- updated the readme to note the additional required explicit `connect` before passing the client to `connect-redis`

I did not revise/update the tests as yet. May do so if I get a moment

As a mimum should get people running as they migrate