### PR TITLE
Remove Node v12 support, add Node v16 build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["12", "14", "16"]
+        node: [14.x, 16.x, 18.x]
     name: Node v${{ matrix.node }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - run: sudo apt-get install -y redis-server

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "redis-v4": "npm:redis@4"
   },
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "bugs": {
     "url": "https://github.com/tj/connect-redis/issues"


### PR DESCRIPTION
## Remove Node v12 in build workflow build.yml.

As Node v12 has long been out of End-of-life. And  @redis/client requires minimum node version  to Node v14. Which causes the following error in Node v12 in build.

Add Node v18 as it's a LTS release with End of life ( 2025-04-30 )
[Node Release](https://github.com/nodejs/Release)
```
error @redis/client@1.4.0: The engine "node" is incompatible with this module. Expected version ">=14". Got "12.22.12" 
error Found incompatible module.

```

Update checkout actions to v3
Update setup-node actions to v3