### PR TITLE
Allow `RedisStore` named export

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -26,7 +26,7 @@ interface RedisStoreOptions {
   disableTouch?: boolean
 }
 
-class RedisStore extends Store {
+export class RedisStore extends Store {
   client: NormalizedRedisClient
   prefix: string
   scanCount: number

--- a/readme.md
+++ b/readme.md
@@ -29,12 +29,16 @@ Import using ESM/Typescript:
 
 ```js
 import RedisStore from "connect-redis"
+// or
+import { RedisStore } from "connect-redis"
 ```
 
 Require using CommonJS:
 
 ```js
 const RedisStore = require("connect-redis").default
+// or
+const RedisStore = require("connect-redis")
 ```
 
 ## API


### PR DESCRIPTION
This PR fixes an issue with ESM + jest

#384 might be touched