### PR TITLE
Add support for async serializer so it can be used with worker threads

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ interface NormalizedRedisClient {
 }
 
 interface Serializer {
-  parse(s: string): SessionData
+  parse(s: string): SessionData | Promise<SessionData>
   stringify(s: SessionData): string
 }
 
@@ -83,7 +83,7 @@ class RedisStore extends Store {
     try {
       let data = await this.client.get(key)
       if (!data) return cb()
-      return cb(null, this.serializer.parse(data))
+      return cb(null, await this.serializer.parse(data))
     } catch (err) {
       return cb(err)
     }

--- a/readme.md
+++ b/readme.md
@@ -113,9 +113,11 @@ This option disables key expiration requiring the user to manually manage key cl
 
 Provide a custom encoder/decoder to use when storing and retrieving session data from Redis (default: `JSON.parse` and `JSON.stringify`).
 
+Optionally `parse` method can be async if need be.
+
 ```ts
 interface Serializer {
-  parse(string): object
+  parse(string): object | Promise<object>
   stringify(object): string
 }
 ```


### PR DESCRIPTION
Hi @tj 

In our use case, we use huge sessions. That's why we needed to use worker threads for parsing.
In order to achieve that, we needed async parse function to be sent into worker thread.

This change won't break for non-async parse functions.

Kindly review
Cheers