### PR TITLE
Add support of Redis JSON

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node: [18, 20, 22]
@@ -18,7 +18,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - run: sudo apt-get install -y redis-server
+
+      - run: sudo apt-get install lsb-release curl gpg
+      - run: curl -fsSL https://packages.redis.io/gpg | sudo gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg
+      - run: sudo chmod 644 /usr/share/keyrings/redis-archive-keyring.gpg
+      - run: echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/redis.list
+      - run: sudo apt-get update
+      - run: sudo apt-get install redis-stack-server
       - run: npm install
       - run: npm run fmt-check
       - run: npm run lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on:  
+on:
   push:
     branches:
       - master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,11 @@
 name: build
-on:
+
+on:  
   push:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "connect-redis",
   "description": "Redis session store for Connect",
-  "version": "8.0.1",
+  "version": "8.0.2",
   "author": "TJ Holowaychuk <tj@vision-media.ca>",
   "contributors": [
     "Marc Harter <wavded@gmail.com>"
@@ -27,6 +27,7 @@
     "prepublishOnly": "vite build",
     "build": "vite build",
     "test": "vitest run --silent --coverage",
+    "test local Redis": "USER_LOCAL_REDIS=1 vitest run --silent --coverage",
     "lint": "tsc --noemit && eslint --max-warnings 0 testdata *.ts",
     "fmt": "prettier --write .",
     "fmt-check": "prettier --check ."
@@ -45,8 +46,8 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
     "express-session": "^1.18.1",
-    "ioredis": "^5.4.1",
-    "prettier": "^3.4.1",
+    "ioredis": "^5.5.0",
+    "prettier": "^3.5.0",
     "prettier-plugin-organize-imports": "^4.1.0",
     "redis": "^4.7.0",
     "ts-node": "^10.9.2",

--- a/readme.md
+++ b/readme.md
@@ -137,3 +137,10 @@ Value used for _count_ parameter in [Redis `SCAN` command](https://redis.io/comm
 
 [1]: https://github.com/NodeRedis/node-redis
 [2]: https://github.com/luin/ioredis
+
+#### useRedisJson
+
+Enable support of JSON for Redis (default: `false`)
+The session data will be stored as JSON objects in DB.
+
+Your Redis server must have the [RedisJSON plugin](https://redis.io/docs/latest/develop/data-types/json/) enabled.

--- a/testdata/server.ts
+++ b/testdata/server.ts
@@ -1,13 +1,18 @@
 import {ChildProcess, spawn} from "node:child_process"
+
 let redisSrv: ChildProcess
 
 export const port = "18543"
 
 export function connect() {
   return new Promise((resolve, reject) => {
-    redisSrv = spawn("redis-server", ["--port", port, "--loglevel", "notice"], {
-      stdio: "inherit",
-    })
+    redisSrv = spawn(
+      "redis-stack-server",
+      ["--port", port, "--loglevel", "notice"],
+      {
+        stdio: "inherit",
+      },
+    )
 
     redisSrv.on("error", function (err) {
       reject(new Error("Error caught spawning the server:" + err.message))


### PR DESCRIPTION
Hi,

As Redis is now supporting JSON, it will be great to also store the session data directly in this format.
This will allows for example to create indexes and find sessions easily against some details as user id or whatever you want. And this is much more optimized than SCAN/MGET over a prefix.

So I propose a small enhancement to add this option (useRedisJson) which is disabled by default to keep standard behavior if not configured.

I've also reworked the build workflow to run test over redis-stack-server under Ubuntu 20.04 which support it via the redis repo.

Hope it will help...

Regards,