### PR TITLE
Improve performance of set method

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -93,8 +93,8 @@ export class RedisStore extends Store {
     let key = this.prefix + sid
     let ttl = this._getTTL(sess)
     try {
-      let val = this.serializer.stringify(sess)
       if (ttl > 0) {
+        let val = this.serializer.stringify(sess)
         if (this.disableTTL) await this.client.set(key, val)
         else await this.client.set(key, val, ttl)
         return cb()


### PR DESCRIPTION

<details>
Hi,

In our system, we store additional keys in Redis and need to sync certain data within session storage. To achieve this, we require a callback that triggers whenever a session is saved to Redis, allowing us to perform operations on our custom keys.

Currently, as a workaround, we have overridden the set method of the Redis store:

```javascript
const store = new RedisStore({ ... });

const originalSet = store.set;
store.set = async function (...args) {
  const session = args?.[1];

  // Custom logic

  return originalSet.apply(store, args);
};
```

However, this approach is fragile and requires validation each time a new version of connect-redis is released.

To make this process more robust and maintainable, we propose adding a built-in onSet callback to `connect-redis`. This would provide a cleaner, more reliable way to execute custom logic when a session is saved.

Let me know if you need refinements!
Thanks in advance 🚀
</details>

Above was the original request. Currently this PR aims to call the `serializer.stringify` when necessary.