### PR TITLE
Define a more generic callback type that returns `unknown` instead of `void`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,8 @@
 import {SessionData, Store} from "express-session"
 
-const noop = (_err?: unknown, _data?: any) => {}
+export type CallbackType = (err?: unknown, data?: unknown) => unknown
+
+const noop: CallbackType = (_err, _data) => {}
 
 interface NormalizedRedisClient {
   get(key: string): Promise<string | null>


### PR DESCRIPTION
The package has implicit type for `get`, `all`, etc.

The type of `get` is inferred as:

```ts
(method) RedisStore.get(sid: string, cb?: (_err?: unknown, _data?: any) => void): Promise<void>
```

Whereas based on the implementation the `get` can be awaited and a value can be returned.

A better approach would've been to use generics, but for now a simple change to `unknown` from `void` is more than acceptable.