### PR TITLE
Fix `node-redis` `createCluster` normalized client

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -48,7 +48,9 @@ export class RedisStore extends Store {
 
   // Create a redis and ioredis compatible client
   private normalizeClient(client: any): NormalizedRedisClient {
-    let isRedis = "scanIterator" in client
+    let isRedis = "scanIterator" in client || "masters" in client;
+    let isRedisCluster = "masters" in client;
+
     return {
       get: (key) => client.get(key),
       set: (key, val, ttl) => {
@@ -63,6 +65,19 @@ export class RedisStore extends Store {
       expire: (key, ttl) => client.expire(key, ttl),
       mget: (keys) => (isRedis ? client.mGet(keys) : client.mget(keys)),
       scanIterator: (match, count) => {
+        // node-redis createCluster impl.
+        if (isRedisCluster) {
+          return (async function *() {
+            for (const master of client.masters) {
+              const nodeClient = await client.nodeClient(master);
+
+              for await (const key of nodeClient.scanIterator({ COUNT: count, MATCH: match })) {
+                yield key;
+              }
+            }
+          })();
+        }
+
         if (isRedis) return client.scanIterator({MATCH: match, COUNT: count})
 
         // ioredis impl.


### PR DESCRIPTION
# Background
When using `node-redis`, a client can be created using `createClient` and `createCluster`. When `createCluster` is used, `scanIterator` is not part of the cluster client, and cannot be called from the root. This caused our `TTL` not to be set, as `isRedis` would be false, which would cause the `redis-io` arguments to be used.

Next to that, if `scanIterator` would be called with the current implementation when using a cluster, it would crash. As neither the `io-redis` implementation nor the `scanIterator` can be used. 

# Fix
We also set `isRedis` to true when `"masters" in client`, which can be used to check whether `createCluster` was used. 
This fixed the mget and set behaviour, as now the correct `node-redis` implementation is used. 

This does not fix `scanIterator` yet, as this cannot be called from the root. https://github.com/redis/node-redis/issues/2657
So this also adds a custom implementation that calls `scanIterator` on each node of the cluster, and yiels all keys from each node. 