### PR TITLE
chore: use public repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/tj/connect-redis.git"
+    "url": "git+https://github.com/tj/connect-redis.git"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.4",


### PR DESCRIPTION
## Summary
- update the package repository metadata to use the public HTTPS GitHub URL
- keep the change limited to package metadata

## Validation
- node package metadata assertion
- git diff --check
- git ls-remote https://github.com/tj/connect-redis.git HEAD
- npm pack --dry-run --ignore-scripts --json passed
